### PR TITLE
Remove inline comments

### DIFF
--- a/examples/complex.hs
+++ b/examples/complex.hs
@@ -12,6 +12,7 @@ main =
     FROM mhart/alpine-node:5.5.0
 
     ENV DIR=/opt/este PORT=8000 \
+        # This is a docker comment
         NODE_ENV=production
 
     RUN apk add --update python python-dev build-base git libpng automake gettext libpng-dev autoconf make zlib-dev nasm

--- a/src/Language/Docker/Normalize.hs
+++ b/src/Language/Docker/Normalize.hs
@@ -20,8 +20,10 @@ trimLines = map strip
 
 normalize :: [String] -> [String]
 normalize allLines =
-    let (_, res) = mapAccumL transform Continue allLines
-    in catMaybes res
+    let (lastState, res) = mapAccumL transform Continue allLines
+    in case lastState of
+           Continue -> catMaybes res
+           Joined l -> catMaybes res ++ [l]
   where
     transform (Joined prev) ('#':_) = (Joined prev, Nothing)
     transform (Joined prev) l =

--- a/src/Language/Docker/Normalize.hs
+++ b/src/Language/Docker/Normalize.hs
@@ -4,13 +4,12 @@ module Language.Docker.Normalize
     ( normalizeEscapedLines
     ) where
 
-import Data.List (intercalate)
-import Data.List.Split (splitOn)
+import Data.List (dropWhileEnd, mapAccumL)
+import Data.Maybe (catMaybes)
 
 data NormalizedLine
-    = Simple String
-    | Join String
-    deriving (Show)
+    = Continue
+    | Joined String
 
 trimLines :: [String] -> [String]
 trimLines = map strip
@@ -19,40 +18,28 @@ trimLines = map strip
     lstrip = dropWhile (`elem` " \t")
     rstrip = reverse . lstrip . reverse
 
-toNormalized :: [String] -> [NormalizedLine]
-toNormalized allLines = reverse (go allLines [])
+normalize :: [String] -> [String]
+normalize allLines =
+    let (_, res) = mapAccumL transform Continue allLines
+    in catMaybes res
   where
+    transform (Joined prev) ('#':_) = (Joined prev, Nothing)
+    transform (Joined prev) l =
+        if endsWithEscape l
+            then (Joined $ prev ++ normalizeLast l, Nothing)
+            else (Continue, Just (prev ++ ' ' : l))
+    transform Continue l =
+        if endsWithEscape l
+            then (Joined (normalizeLast l), Nothing)
+            else (Continue, Just l)
+    --
     endsWithEscape "" = False
-    endsWithEscape s = (head . reverse $ s) == '\\'
-    startsWithComment ('#':_) = True
-    startsWithComment _ = False
-    go [] acc = acc
-    go (l:[]) acc = (Simple l) : acc
-    go (l1:l2:rest) acc =
-        if not (endsWithEscape l1)
-            then go (l2 : rest) (Simple l1 : acc)
-            else if startsWithComment l2
-                     then go rest (Join (normalizeLast l1) : acc)
-                     else go (l2 : rest) (Join (normalizeLast l1) : acc)
-
-normalizeLast :: String -> String
-normalizeLast = reverse . go ""
-  where
-    go acc "" = acc
-    go acc ('\\':rest) = go (' ' : acc) rest
-    go acc (a:rest) = go (a : acc) rest
-
-fromNormalized :: [NormalizedLine] -> [String]
-fromNormalized norm = reverse (go norm [])
-  where
-    go [] acc = acc
-    go (Join l1:Simple l2:rest) acc = go rest ((l1 ++ l2) : acc)
-    go (Join l1:Join l2:rest) acc = go (Join (l1 ++ l2) : rest) acc
-    go (Join l:[]) acc = l : acc
-    go (Simple l:rest) acc = go rest (l : acc)
+    endsWithEscape s = last s == '\\'
+    --
+    normalizeLast = dropWhileEnd (== '\\')
 
 -- | Remove new line escapes and join escaped lines together on one line
 --   to simplify parsing later on. Escapes are replaced with line breaks
 --   to not alter the line numbers.
 normalizeEscapedLines :: String -> String
-normalizeEscapedLines = unlines . fromNormalized . toNormalized . trimLines . lines
+normalizeEscapedLines = unlines . normalize . trimLines . lines

--- a/src/Language/Docker/Normalize.hs
+++ b/src/Language/Docker/Normalize.hs
@@ -7,40 +7,52 @@ module Language.Docker.Normalize
 import Data.List (intercalate)
 import Data.List.Split (splitOn)
 
-escapePlaceHolder :: String
-escapePlaceHolder = "\\\\"
+data NormalizedLine
+    = Simple String
+    | Join String
+    deriving (Show)
 
-escapeSeq :: String
-escapeSeq = "\\\n"
-
-replace :: Eq a => [a] -> [a] -> [a] -> [a]
-replace old new = intercalate new . splitOn old
-
-count :: Eq a => [a] -> [a] -> Int
-count s x = length (splitOn x s) - 1
-
-trimLines :: String -> String
-trimLines s = unlines $ map strip $ lines s
+trimLines :: [String] -> [String]
+trimLines = map strip
   where
     strip = lstrip . rstrip
-    lstrip = dropWhile (`elem` (" \t" :: String))
+    lstrip = dropWhile (`elem` " \t")
     rstrip = reverse . lstrip . reverse
 
-replaceEscapeSigns :: String -> String
-replaceEscapeSigns = replace escapeSeq escapePlaceHolder
-
-removeEscapePlaceholder :: String -> String
-removeEscapePlaceholder = replace escapePlaceHolder " "
-
-compensateLinebreaks :: String -> String
-compensateLinebreaks s = concatMap compensate $ lines s
+toNormalized :: [String] -> [NormalizedLine]
+toNormalized allLines = reverse (go allLines [])
   where
-    compensate line = line ++ "\n" ++ genLinebreaks line
-    genLinebreaks line = concat $ replicate (count line escapePlaceHolder) "\n"
+    endsWithEscape "" = False
+    endsWithEscape s = (head . reverse $ s) == '\\'
+    startsWithComment ('#':_) = True
+    startsWithComment _ = False
+    go [] acc = acc
+    go (l:[]) acc = (Simple l) : acc
+    go (l1:l2:rest) acc =
+        if not (endsWithEscape l1)
+            then go (l2 : rest) (Simple l1 : acc)
+            else if startsWithComment l2
+                     then go rest (Join (normalizeLast l1) : acc)
+                     else go (l2 : rest) (Join (normalizeLast l1) : acc)
+
+normalizeLast :: String -> String
+normalizeLast = reverse . go ""
+  where
+    go acc "" = acc
+    go acc ('\\':rest) = go (' ' : acc) rest
+    go acc (a:rest) = go (a : acc) rest
+
+fromNormalized :: [NormalizedLine] -> [String]
+fromNormalized norm = reverse (go norm [])
+  where
+    go [] acc = acc
+    go (Join l1:Simple l2:rest) acc = go rest ((l1 ++ l2) : acc)
+    go (Join l1:Join l2:rest) acc = go (Join (l1 ++ l2) : rest) acc
+    go (Join l:[]) acc = l : acc
+    go (Simple l:rest) acc = go rest (l : acc)
 
 -- | Remove new line escapes and join escaped lines together on one line
 --   to simplify parsing later on. Escapes are replaced with line breaks
 --   to not alter the line numbers.
 normalizeEscapedLines :: String -> String
-normalizeEscapedLines s =
-    removeEscapePlaceholder $ compensateLinebreaks $ replaceEscapeSigns $ trimLines s
+normalizeEscapedLines = unlines . fromNormalized . toNormalized . trimLines . lines

--- a/src/Language/Docker/Normalize.hs
+++ b/src/Language/Docker/Normalize.hs
@@ -20,19 +20,52 @@ trimLines = map strip
 -- Finds all lines ending with \ and joins them with the next line using
 -- a single space. If the next line is a comment, then the comment line is
 -- deleted. It finally adds the same amount of new lines for each of the
--- lines it joined, in order to preser the line count in the document.
+-- lines it joined, in order to preserve the line count in the document.
 normalize :: [String] -> [String]
 normalize allLines =
-    let (lastState, res) = mapAccumL transform Continue allLines
+    let (lastState, res) -- mapAccumL is the idea of a for loop with a variable holding
+                         -- some state and another variable where we append the final result
+                         -- of the looping operation. For each line in lines, apply the transform
+                         -- function. This function always returns a new state, and another element
+                         -- to append to the final result. The ending result of mapAccumL is the final
+                         -- state variale and the resulting list of values. We initialize the loop with
+                         -- the 'Continue' state, which means "no special action to do next"
+         = mapAccumL transform Continue allLines
     in case lastState of
-           Continue -> catMaybes res
-           Joined l times -> catMaybes res ++ [l ++ padNewlines times]
+           Continue -- The last line of the document is a normal line, cleanup and return
+            -> catMaybes res
+           Joined l times -- The last line contains a \, so we need to add the buffered
+                          -- line back to the result, pad with newlines and cleanup
+            -> catMaybes res ++ [l ++ padNewlines times]
   where
+    normalizeLast = dropWhileEnd (== '\\')
+    -- | Checks the result of the previous operation in the loop (first argument)
+    --
+    -- If the previous result is a 'Joined' operation, then we merge the previous
+    -- and the current line in a single line and return it.
+    --
+    -- If the current line ends with a \, then we produce a 'Joined' state as result
+    -- of this looping operation.
+    --
+    -- If the previous 2 conditions are true at the same time, then we produce a new
+    -- 'Joined' state holding the concatenation of the Joined buffer and the previous line
+    -- and we return 'Nothing' as an indication that this line does not form part of the
+    -- final result.
+    transform :: NormalizedLine -> String -> (NormalizedLine, Maybe String)
+    -- If we are buffering lines, and the next line is a comment,
+    -- we simply ignore the comment and remember to add a newline
     transform (Joined prev times) ('#':_) = (Joined prev (times + 1), Nothing)
+    -- If we are buffering lines, then we check whether the current line end with \,
+    -- if it does, then we merged it into the buffered state, otherwise we just yield
+    -- the concatanation of the buffer and the current line as result, after padding with
+    -- newlines
     transform (Joined prev times) l =
         if endsWithEscape l
             then (Joined (prev ++ ' ' : normalizeLast l) (times + 1), Nothing)
             else (Continue, Just (prev ++ ' ' : l ++ padNewlines times))
+    -- When not buffering lines, then we just check if we need to start doing it by checking
+    -- whether or not the current line ends with \. If it does not, then we just yield the
+    -- current line as part of the result
     transform Continue l =
         if endsWithEscape l
             then (Joined (normalizeLast l) 1, Nothing)
@@ -40,8 +73,6 @@ normalize allLines =
     --
     endsWithEscape "" = False
     endsWithEscape s = last s == '\\'
-    --
-    normalizeLast = dropWhileEnd (== '\\')
     --
     padNewlines times = replicate times '\n'
 

--- a/test/Language/Docker/ParserSpec.hs
+++ b/test/Language/Docker/ParserSpec.hs
@@ -146,9 +146,9 @@ spec = do
                             ]
                     longEscapedCmdExpected =
                         concat
-                            [ "RUN wget https://download.com/${version}.tar.gz -O /tmp/logstash.tar.gz &&  "
-                            , "(cd /tmp && tar zxf logstash.tar.gz && mv logstash-${version} /opt/logstash &&  "
-                            , "rm logstash.tar.gz) &&  "
+                            [ "RUN wget https://download.com/${version}.tar.gz -O /tmp/logstash.tar.gz && "
+                            , "(cd /tmp && tar zxf logstash.tar.gz && mv logstash-${version} /opt/logstash && "
+                            , "rm logstash.tar.gz) && "
                             , "(cd /opt/logstash &&  "
                             , "/opt/logstash/bin/plugin install contrib)\n"
                             ]

--- a/test/Language/Docker/ParserSpec.hs
+++ b/test/Language/Docker/ParserSpec.hs
@@ -85,12 +85,12 @@ spec = do
         describe "parse RUN" $
             it "escaped with space before" $
             let dockerfile = unlines ["RUN yum install -y \\ ", "imagemagick \\ ", "mysql"]
-            in assertAst dockerfile [Run ["yum", "install", "-y", "imagemagick", "mysql"], EOL]
+            in assertAst dockerfile [Run ["yum", "install", "-y", "imagemagick", "mysql"], EOL, EOL]
 
         describe "parse CMD" $ do
             it "one line cmd" $ assertAst "CMD true" [Cmd ["true"]]
             it "cmd over several lines" $
-                assertAst "CMD true \\\n && true" [Cmd ["true", "&&", "true"]]
+                assertAst "CMD true \\\n && true" [Cmd ["true", "&&", "true"], EOL]
             it "quoted command params" $ assertAst "CMD [\"echo\",  \"1\"]" [Cmd ["echo", "1"]]
 
         describe "parse SHELL" $ do
@@ -128,12 +128,12 @@ spec = do
                                  , "DEBIAN_FRONTEND=noninteractive"
                                  ]
                     normalizedDockerfile = unlines [ "FROM busybox"
-                                                   , "ENV NODE_VERSION=v5.7.1  DEBIAN_FRONTEND=noninteractive"
+                                                   , "ENV NODE_VERSION=v5.7.1  DEBIAN_FRONTEND=noninteractive\n"
                                                    ]
                 in normalizeEscapedLines dockerfile `shouldBe` normalizedDockerfile
             it "join escaped lines" $
                 let dockerfile = unlines ["ENV foo=bar \\", "baz=foz"]
-                    normalizedDockerfile = unlines ["ENV foo=bar  baz=foz"]
+                    normalizedDockerfile = unlines ["ENV foo=bar  baz=foz", ""]
                 in normalizeEscapedLines dockerfile `shouldBe` normalizedDockerfile
             it "join long CMD" $
                 let longEscapedCmd =
@@ -146,11 +146,15 @@ spec = do
                             ]
                     longEscapedCmdExpected =
                         concat
-                            [ "RUN wget https://download.com/${version}.tar.gz -O /tmp/logstash.tar.gz && "
-                            , "(cd /tmp && tar zxf logstash.tar.gz && mv logstash-${version} /opt/logstash && "
-                            , "rm logstash.tar.gz) && "
+                            [ "RUN wget https://download.com/${version}.tar.gz -O /tmp/logstash.tar.gz &&  "
+                            , "(cd /tmp && tar zxf logstash.tar.gz && mv logstash-${version} /opt/logstash &&  "
+                            , "rm logstash.tar.gz) &&  "
                             , "(cd /opt/logstash &&  "
                             , "/opt/logstash/bin/plugin install contrib)\n"
+                            , "\n"
+                            , "\n"
+                            , "\n"
+                            , "\n"
                             ]
                 in normalizeEscapedLines longEscapedCmd `shouldBe` longEscapedCmdExpected
         describe "expose" $ do

--- a/test/Language/Docker/ParserSpec.hs
+++ b/test/Language/Docker/ParserSpec.hs
@@ -85,12 +85,12 @@ spec = do
         describe "parse RUN" $
             it "escaped with space before" $
             let dockerfile = unlines ["RUN yum install -y \\ ", "imagemagick \\ ", "mysql"]
-            in assertAst dockerfile [Run ["yum", "install", "-y", "imagemagick", "mysql"], EOL, EOL]
+            in assertAst dockerfile [Run ["yum", "install", "-y", "imagemagick", "mysql"], EOL]
 
         describe "parse CMD" $ do
             it "one line cmd" $ assertAst "CMD true" [Cmd ["true"]]
             it "cmd over several lines" $
-                assertAst "CMD true \\\n && true" [Cmd ["true", "&&", "true"], EOL]
+                assertAst "CMD true \\\n && true" [Cmd ["true", "&&", "true"]]
             it "quoted command params" $ assertAst "CMD [\"echo\",  \"1\"]" [Cmd ["echo", "1"]]
 
         describe "parse SHELL" $ do
@@ -128,12 +128,12 @@ spec = do
                                  , "DEBIAN_FRONTEND=noninteractive"
                                  ]
                     normalizedDockerfile = unlines [ "FROM busybox"
-                                                   , "ENV NODE_VERSION=v5.7.1  DEBIAN_FRONTEND=noninteractive\n"
+                                                   , "ENV NODE_VERSION=v5.7.1  DEBIAN_FRONTEND=noninteractive"
                                                    ]
                 in normalizeEscapedLines dockerfile `shouldBe` normalizedDockerfile
             it "join escaped lines" $
                 let dockerfile = unlines ["ENV foo=bar \\", "baz=foz"]
-                    normalizedDockerfile = unlines ["ENV foo=bar  baz=foz", ""]
+                    normalizedDockerfile = unlines ["ENV foo=bar  baz=foz"]
                 in normalizeEscapedLines dockerfile `shouldBe` normalizedDockerfile
             it "join long CMD" $
                 let longEscapedCmd =
@@ -151,10 +151,6 @@ spec = do
                             , "rm logstash.tar.gz) &&  "
                             , "(cd /opt/logstash &&  "
                             , "/opt/logstash/bin/plugin install contrib)\n"
-                            , "\n"
-                            , "\n"
-                            , "\n"
-                            , "\n"
                             ]
                 in normalizeEscapedLines longEscapedCmd `shouldBe` longEscapedCmdExpected
         describe "expose" $ do


### PR DESCRIPTION
Re-implemented the normalizer to remove comment lines inside other instructions.

This solves cases like https://github.com/hadolint/hadolint/issues/76