### PR TITLE
Fix another case of ENV parsing

### DIFF
--- a/src/Language/Docker/EDSL/Quasi.hs
+++ b/src/Language/Docker/EDSL/Quasi.hs
@@ -9,7 +9,6 @@ import Language.Haskell.TH.Syntax
 
 import Language.Docker.EDSL
 import qualified Language.Docker.Parser as Parser
-import Language.Docker.Syntax
 import Language.Docker.Syntax.Lift ()
 
 -- | Quasiquoter for embedding dockerfiles on the EDSL
@@ -30,9 +29,7 @@ edockerfileE :: String -> ExpQ
 edockerfileE e =
     case Parser.parseString e of
         Left err -> fail (show err)
-        Right d ->
-            let d' = filterEOL d
-            in [|embed d'|]
+        Right d -> [|embed d|]
 
 dockerfile :: QuasiQuoter
 dockerfile =
@@ -47,9 +44,4 @@ dockerfileE :: String -> ExpQ
 dockerfileE e =
     case Parser.parseString e of
         Left err -> fail (show err)
-        Right d ->
-            let d' = filterEOL d
-            in lift d'
-
-filterEOL :: [InstructionPos] -> [InstructionPos]
-filterEOL = filter (\(InstructionPos i _ _) -> i /= EOL)
+        Right d -> lift d

--- a/src/Language/Docker/PrettyPrint.hs
+++ b/src/Language/Docker/PrettyPrint.hs
@@ -128,7 +128,6 @@ prettyPrintInstruction i =
         Healthcheck c -> do
             text "HEALTHCHECK"
             text c
-        EOL -> mempty
   where
     (>>) = (<+>)
     return = (mempty <>)

--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -72,7 +72,6 @@ data Instruction
     | Healthcheck String
     | Comment String
     | OnBuild Instruction
-    | EOL
     deriving (Eq, Ord, Show)
 
 type Filename = String


### PR DESCRIPTION
The broken case was found in one of the failing integration tests.

This required a full re-implementation of the Lexer. I decided to drop
the makeTokenParser since it has been a struggle form the start to manage
the way it munges whitespace.

Instead, implemented the token parsers in the lexer by hand, since we only
needed a few of them.