### PR TITLE
Fixed another normalization case

### DIFF
--- a/examples/complex.hs
+++ b/examples/complex.hs
@@ -13,6 +13,7 @@ main =
 
     ENV DIR=/opt/este PORT=8000 \
         # This is a docker comment
+
         NODE_ENV=production
 
     RUN apk add --update python python-dev build-base git libpng automake gettext libpng-dev autoconf make zlib-dev nasm

--- a/integration-tests/parse_files.sh
+++ b/integration-tests/parse_files.sh
@@ -82,7 +82,6 @@ function clone_repos() {
     git_named_clone https://github.com/seapy/dockerfiles.git seapy-dockerfiles &
     git_named_clone https://github.com/nickstenning/dockerfiles.git nickstenning-dockerfiles &
     git_named_clone https://github.com/crosbymichael/Dockerfiles.git crosbymichael-dockerfiles &
-    git_named_clone https://github.com/SvenDowideit/dockerfiles.git svendowideit-dockerfiles &
     git_named_clone https://github.com/codenvy/dockerfiles.git codenvy-dockerfiles &
     git_named_clone https://github.com/couchbase/docker.git couchbase-docker &
     git_named_clone https://github.com/EvaEngine/Dockerfiles.git evaengine-dockerfiles &

--- a/src/Language/Docker/Normalize.hs
+++ b/src/Language/Docker/Normalize.hs
@@ -55,6 +55,8 @@ normalize allLines =
     -- If we are buffering lines, and the next line is a comment,
     -- we simply ignore the comment and remember to add a newline
     transform (Joined prev times) ('#':_) = (Joined prev (times + 1), Nothing)
+    -- We do the same if we are buffering lines and the next one is empty
+    transform (Joined prev times) "" = (Joined prev (times + 1), Nothing)
     -- If we are buffering lines, then we check whether the current line end with \,
     -- if it does, then we merged it into the buffered state, otherwise we just yield
     -- the concatanation of the buffer and the current line as result, after padding with


### PR DESCRIPTION
When a line ends with \ and the next one is empty, that's still valid