### PR TITLE
Fixed the LABEL parser

### DIFF
--- a/src/Language/Docker/Lexer.hs
+++ b/src/Language/Docker/Lexer.hs
@@ -45,14 +45,14 @@ caseInsensitiveChar c = char (toUpper c) <|> char (toLower c)
 caseInsensitiveString :: String -> Parser String
 caseInsensitiveString s = mapM caseInsensitiveChar s <?> "\"" ++ s ++ "\""
 
-charsWithEscapedSpaces :: Parser String
-charsWithEscapedSpaces = do
-    buf <- many1 (noneOf "\n\t\\ ")
+charsWithEscapedSpaces :: String -> Parser String
+charsWithEscapedSpaces stopChars = do
+    buf <- many1 $ noneOf ("\n\t\\ " ++ stopChars)
     try (jumpEscapeSequence buf) <|> return buf
   where
     jumpEscapeSequence buf = do
         void $ string "\\ "
-        rest <- charsWithEscapedSpaces
+        rest <- charsWithEscapedSpaces stopChars
         return $ buf ++ ' ' : rest
 
 lexeme :: Parser a -> Parser a

--- a/src/Language/Docker/Parser.hs
+++ b/src/Language/Docker/Parser.hs
@@ -91,14 +91,14 @@ doubleQuotedValue = between (char '"') (char '"') (many1 $ noneOf "\n\"")
 singleQuotedValue :: Parser String
 singleQuotedValue = between (void $ char '\'') (void $ char '\'') (many $ noneOf "\n'")
 
-singleValue :: Parser String
-singleValue = try doubleQuotedValue <|> try singleQuotedValue <|> charsWithEscapedSpaces
+singleValue :: String -> Parser String
+singleValue stopChars = try doubleQuotedValue <|> try singleQuotedValue <|> charsWithEscapedSpaces stopChars
 
 pair :: Parser (String, String)
 pair = do
-    key <- many (noneOf "\t\n= ")
+    key <- singleValue "="
     void $ char '='
-    value <- singleValue
+    value <- singleValue ""
     return (key, value)
 
 pairs :: Parser Pairs
@@ -107,7 +107,7 @@ pairs = pair `sepBy1` spaces1
 label :: Parser Instruction
 label = do
     reserved "LABEL"
-    p <- pairs
+    p <- envPairs
     return $ Label p
 
 arg :: Parser Instruction

--- a/src/Language/Docker/Parser.hs
+++ b/src/Language/Docker/Parser.hs
@@ -92,7 +92,8 @@ singleQuotedValue :: Parser String
 singleQuotedValue = between (void $ char '\'') (void $ char '\'') (many $ noneOf "\n'")
 
 singleValue :: String -> Parser String
-singleValue stopChars = try doubleQuotedValue <|> try singleQuotedValue <|> charsWithEscapedSpaces stopChars
+singleValue stopChars =
+    try doubleQuotedValue <|> try singleQuotedValue <|> charsWithEscapedSpaces stopChars
 
 pair :: Parser (String, String)
 pair = do
@@ -101,13 +102,13 @@ pair = do
     value <- singleValue ""
     return (key, value)
 
-pairs :: Parser Pairs
-pairs = pair `sepBy1` spaces1
+pairsList :: Parser Pairs
+pairsList = pair `sepBy1` spaces1
 
 label :: Parser Instruction
 label = do
     reserved "LABEL"
-    p <- envPairs
+    p <- pairs
     return $ Label p
 
 arg :: Parser Instruction
@@ -119,11 +120,11 @@ arg = do
 env :: Parser Instruction
 env = do
     reserved "ENV"
-    p <- envPairs
+    p <- pairs
     return $ Env p
 
-envPairs :: Parser Pairs
-envPairs = try pairs <|> singlePair
+pairs :: Parser Pairs
+pairs = try pairsList <|> singlePair
 
 singlePair :: Parser Pairs
 singlePair = do

--- a/test/Language/Docker/ParserSpec.hs
+++ b/test/Language/Docker/ParserSpec.hs
@@ -36,6 +36,8 @@ spec = do
 
         describe "parse LABEL" $ do
             it "parse label" $ assertAst "LABEL foo=bar" [Label[("foo", "bar")]]
+            it "parse space separated label" $ assertAst "LABEL foo bar baz" [Label[("foo", "bar baz")]]
+            it "parse quoted labels" $ assertAst "LABEL \"foo bar\"=baz" [Label[("foo bar", "baz")]]
             it "parses multiline labels" $
                 let dockerfile = unlines [ "LABEL foo=bar \\", "hobo=mobo"]
                     ast = [ Label [("foo", "bar"), ("hobo", "mobo")] ]


### PR DESCRIPTION
It seems like LABEL and ENV uses the same parsing lines in docker build,
so let's do the same. Also, labels allow quoted keys, and ENV does as well