### PR TITLE
Fixed EXPOSE parsing for ranges

### DIFF
--- a/src/Language/Docker/EDSL.hs
+++ b/src/Language/Docker/EDSL.hs
@@ -125,7 +125,7 @@ udpPort = flip Syntax.Port Syntax.UDP
 variablePort :: String -> Syntax.Port
 variablePort varName = Syntax.PortStr ('$' : varName)
 
-portRange :: Syntax.Port -> Syntax.Port -> Syntax.Ports
+portRange :: Integer -> Integer -> Syntax.Port
 portRange = Syntax.PortRange
 
 run :: MonadFree EInstruction m => String -> m ()

--- a/src/Language/Docker/Parser.hs
+++ b/src/Language/Docker/Parser.hs
@@ -149,20 +149,20 @@ add = do
 expose :: Parser Instruction
 expose = do
     reserved "EXPOSE"
-    ps <- try portRange <|> ports
+    ps <- ports
     return $ Expose ps
 
 port :: Parser Port
-port = portVariable <|> try portWithProtocol <|> portInt
+port = portVariable <|> try portRange <|> try portWithProtocol <|> portInt
 
 ports :: Parser Ports
 ports = Ports <$> port `sepEndBy1` space
 
-portRange :: Parser Ports
+portRange :: Parser Port
 portRange = do
-    start <- portInt
+    start <- natural
     void $ char '-'
-    finish <- portInt
+    finish <- natural
     return $ PortRange start finish
 
 portInt :: Parser Port

--- a/src/Language/Docker/PrettyPrint.hs
+++ b/src/Language/Docker/PrettyPrint.hs
@@ -66,6 +66,7 @@ prettyPrintJSON as = brackets $ hsep $ intersperse comma $ map (doubleQuotes . t
 
 prettyPrintPort :: Port -> Doc
 prettyPrintPort (PortStr str) = text str
+prettyPrintPort (PortRange start stop) = integer start <> text "-" <> integer stop
 prettyPrintPort (Port num TCP) = integer num <> char '/' <> text "tcp"
 prettyPrintPort (Port num UDP) = integer num <> char '/' <> text "udp"
 
@@ -90,10 +91,6 @@ prettyPrintInstruction i =
         Expose (Ports ps) -> do
             text "EXPOSE"
             hsep (map prettyPrintPort ps)
-        Expose (PortRange (Port start TCP) (Port finish TCP)) -> do
-            text "EXPOSE"
-            integer start <> text "-" <> integer finish
-        Expose range@(PortRange _ _) -> error $ "Not a valid Port Range " ++ show range
         Volume dir -> do
             text "VOLUME"
             text dir

--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -15,11 +15,12 @@ data Port
     = Port Integer
            Protocol
     | PortStr String
+    | PortRange Integer
+                Integer
     deriving (Show, Eq, Ord)
 
-data Ports =
-     Ports [Port]
-    | PortRange Port Port
+newtype Ports =
+    Ports [Port]
     deriving (Show, Eq, Ord)
 
 type Directory = String

--- a/test/Language/Docker/EDSLSpec.hs
+++ b/test/Language/Docker/EDSLSpec.hs
@@ -38,7 +38,7 @@ spec = do
             let r = prettyPrint $ toDockerfile (do
                         from "scratch"
                         expose $ ports [variablePort "PORT", tcpPort 80, udpPort 51]
-                        expose $ portRange (tcpPort 90) (tcpPort 100))
+                        expose $ ports [portRange 90 100])
             r `shouldBe` unlines [ "FROM scratch"
                                  , "EXPOSE $PORT 80/tcp 51/udp"
                                  , "EXPOSE 90-100"

--- a/test/Language/Docker/ParserSpec.hs
+++ b/test/Language/Docker/ParserSpec.hs
@@ -189,8 +189,8 @@ spec = do
                 let content = "EXPOSE $PORT 8080 8081/UDP"
                 parse expose "" content `shouldBe` Right (Expose (Ports [PortStr "$PORT", Port 8080 TCP, Port 8081 UDP]))
             it "should handle port ranges" $ do
-                let content = "EXPOSE 8080-8085"
-                parse expose "" content `shouldBe` Right (Expose (PortRange (Port 8080 TCP) (Port 8085 TCP)))
+                let content = "EXPOSE 80 81 8080-8085"
+                parse expose "" content `shouldBe` Right (Expose (Ports [Port 80 TCP, Port 81 TCP, PortRange 8080 8085]))
 
         describe "syntax" $ do
             it "should handle lowercase instructions (#7 - https://github.com/beijaflor-io/haskell-language-dockerfile/issues/7)" $ do


### PR DESCRIPTION
It looks like it is also possible to do this:

`EXPOSE 80 81 8080-8085`

Unfortunatey, this required another change in the Syntax model