### PR TITLE
Improve COPY and ADD parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
   # variable, such as using --stack-yaml to point to a different file.
   - env: ARGS="--resolver lts"
 
-  - env: ARGS="--resolver lts-9.13"
+  - env: ARGS=""
 
   # Nightly builds are allowed to fail
   - env: ARGS="--resolver nightly"
@@ -26,7 +26,7 @@ matrix:
   - env: ARGS="--resolver lts"
     os: osx
 
-  - env: ARGS="--resolver lts-9.13"
+  - env: ARGS=""
     os: osx
 
   - env: ARGS="--resolver nightly"
@@ -34,7 +34,7 @@ matrix:
 
   - env:
       - PURPOSE="Integration tests"
-      - ARGS="--resolver lts-9.13"
+      - ARGS=""
     script: make tests
 
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ main = putStr $ toDockerfileStr $ do
 ```haskell
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
 import Control.Monad
 import Language.Docker
 import Data.String (fromString)
@@ -104,6 +105,7 @@ support more features like file globbing:
 
 ```haskell
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
 import           Language.Docker
 import qualified System.Directory     as Directory
 import qualified System.FilePath      as FilePath

--- a/README.md
+++ b/README.md
@@ -79,12 +79,14 @@ main = putStr $ toDockerfileStr $ do
 {-# LANGUAGE OverloadedStrings #-}
 import Control.Monad
 import Language.Docker
+import Data.String (fromString)
+
 tags = ["7.8", "7.10", "8"]
 cabalSandboxBuild packageName = do
     let cabalFile = packageName ++ ".cabal"
     run "cabal sandbox init"
     run "cabal update"
-    add cabalFile ("/app/" ++ cabalFile)
+    add [fromString cabalFile] (fromString $ "/app/" ++ cabalFile)
     run "cabal install --only-dep -j"
     add "." "/app/"
     run "cabal build"
@@ -106,6 +108,7 @@ import           Language.Docker
 import qualified System.Directory     as Directory
 import qualified System.FilePath      as FilePath
 import qualified System.FilePath.Glob as Glob
+import Data.String (fromString)
 main = do
     str <- toDockerfileStrIO $ do
         fs <- liftIO $ do
@@ -113,7 +116,7 @@ main = do
             fs <- Glob.glob "./test/*.hs"
             return (map (FilePath.makeRelative cwd) fs)
         from "ubuntu"
-        mapM_ (\f -> add f ("/app/" ++ FilePath.takeFileName f)) fs
+	mapM_ (\f -> add [fromString f] (fromString $ "/app/" ++ takeFileName f)) fs
     putStr str
 ```
 

--- a/examples/templating.hs
+++ b/examples/templating.hs
@@ -1,19 +1,25 @@
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 import Control.Monad
 import Language.Docker
+import Language.Docker.Syntax
+
 tags = ["7.8", "7.10", "8"]
+
 cabalSandboxBuild packageName = do
     let cabalFile = packageName ++ ".cabal"
     run "cabal sandbox init"
     run "cabal update"
-    add cabalFile ("/app/" ++ cabalFile)
+    add [SourcePath cabalFile] (TargetPath $ "/app/" ++ cabalFile)
     run "cabal install --only-dep -j"
-    add "." "/app/"
+    add ["."] "/app/"
     run "cabal build"
+
 main =
     forM_ tags $ \tag -> do
-        let df = toDockerfileStr $ do
-            from ("haskell" `tagged` tag)
-            cabalSandboxBuild "mypackage"
+        let df =
+                toDockerfileStr $ do
+                    from ("haskell" `tagged` tag)
+                    cabalSandboxBuild "mypackage"
         writeFile ("./examples/templating-" ++ tag ++ ".dockerfile") df

--- a/examples/templating.hs
+++ b/examples/templating.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
 
 import Control.Monad
 import Language.Docker
 import Language.Docker.Syntax
 
+tags :: [String]
 tags = ["7.8", "7.10", "8"]
 
 cabalSandboxBuild packageName = do

--- a/examples/test-dockerfile.hs
+++ b/examples/test-dockerfile.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
 import Language.Docker
 
 main :: IO ()

--- a/examples/test-dockerfile.hs
+++ b/examples/test-dockerfile.hs
@@ -1,9 +1,12 @@
-import           Language.Docker
+{-# LANGUAGE OverloadedStrings #-}
+import Language.Docker
 
 main :: IO ()
-main = writeFile "./examples/test-dockerfile.dockerfile" $ toDockerfileStr $ do
-    from (tagged "fpco/stack-build" "lts-6.9")
-    add "." "/app/language-docker"
-    workdir "/app/language-docker"
-    run "stack build --test --only-dependencies"
-    cmd "stack test"
+main =
+    writeFile "./examples/test-dockerfile.dockerfile" $
+    toDockerfileStr $ do
+        from (tagged "fpco/stack-build" "lts-6.9")
+        add ["."] "/app/language-docker"
+        workdir "/app/language-docker"
+        run "stack build --test --only-dependencies"
+        cmd "stack test"

--- a/language-docker.cabal
+++ b/language-docker.cabal
@@ -1,6 +1,8 @@
--- This file has been generated from package.yaml by hpack version 0.17.1.
+-- This file has been generated from package.yaml by hpack version 0.20.0.
 --
 -- see: https://github.com/sol/hpack
+--
+-- hash: 1f57a126098c830eac5ce99e38c1b35596513d866364beff62006b00662b9668
 
 name:           language-docker
 version:        1.0.0
@@ -35,24 +37,24 @@ library
       src
   ghc-options: -Wall -fno-warn-unused-do-bind -fno-warn-orphans
   build-depends:
-      base >=4.8 && <5
+      Glob
+    , aeson
+    , base >=4.8 && <5
     , bytestring >=0.10
+    , directory
+    , filepath
+    , free
+    , mtl
     , parsec >=3.1
     , pretty
     , split >=0.2
-    , free
-    , mtl
-    , transformers
     , template-haskell
+    , text
     , th-lift
     , th-lift-instances
-    , text
-    , yaml
-    , aeson
-    , Glob
+    , transformers
     , unordered-containers
-    , directory
-    , filepath
+    , yaml
   exposed-modules:
       Language.Docker
       Language.Docker.Parser
@@ -76,36 +78,34 @@ test-suite hspec
   hs-source-dirs:
       test
   build-depends:
-      base >=4.8 && <5
+      Glob
+    , HUnit >=1.2
+    , QuickCheck
+    , aeson
+    , base >=4.8 && <5
     , bytestring >=0.10
+    , directory
+    , filepath
+    , free
+    , hspec
+    , language-docker
+    , mtl
     , parsec >=3.1
     , pretty
+    , process
     , split >=0.2
-    , free
-    , mtl
-    , transformers
     , template-haskell
+    , text
     , th-lift
     , th-lift-instances
-    , text
-    , yaml
-    , aeson
-    , Glob
+    , transformers
     , unordered-containers
-    , directory
-    , filepath
-    , hspec
-    , QuickCheck
-    , language-docker
-    , Glob
-    , directory
-    , filepath
-    , process
-    , HUnit >=1.2
+    , yaml
   other-modules:
       Language.Docker.EDSL.PluginsSpec
       Language.Docker.EDSL.QuasiSpec
       Language.Docker.EDSLSpec
       Language.Docker.ExamplesSpec
       Language.Docker.ParserSpec
+      Paths_language_docker
   default-language: Haskell2010

--- a/language-docker.cabal
+++ b/language-docker.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1f57a126098c830eac5ce99e38c1b35596513d866364beff62006b00662b9668
+-- hash: 840b34b7801f56b6e0a9cb1f9116186f97afb8a726f03b640822d638a71132e4
 
 name:           language-docker
 version:        1.0.0
@@ -47,6 +47,7 @@ library
     , mtl
     , parsec >=3.1
     , pretty
+    , semigroups
     , split >=0.2
     , template-haskell
     , text
@@ -93,6 +94,7 @@ test-suite hspec
     , parsec >=3.1
     , pretty
     , process
+    , semigroups
     , split >=0.2
     , template-haskell
     , text

--- a/package.yaml
+++ b/package.yaml
@@ -43,6 +43,7 @@ dependencies:
   - unordered-containers
   - directory
   - filepath
+  - semigroups
 
 library:
   source-dirs: src

--- a/src/Language/Docker.hs
+++ b/src/Language/Docker.hs
@@ -56,12 +56,14 @@ module Language.Docker
     , Language.Docker.Syntax.Instruction(..)
     , Language.Docker.Syntax.InstructionPos(..)
     , Language.Docker.Syntax.BaseImage(..)
+    , Language.Docker.Syntax.SourcePath(..)
+    , Language.Docker.Syntax.TargetPath(..)
+    , Language.Docker.Syntax.Chown(..)
+    , Language.Docker.Syntax.CopySource(..)
     , Language.Docker.Syntax.Image
     , Language.Docker.Syntax.Tag
     , Language.Docker.Syntax.Ports
     , Language.Docker.Syntax.Directory
-    , Language.Docker.Syntax.SourcePath
-    , Language.Docker.Syntax.TargetPath
     , Language.Docker.Syntax.Arguments
     , Language.Docker.Syntax.Pairs
     , Language.Docker.Syntax.Filename
@@ -69,9 +71,7 @@ module Language.Docker
     -- * Re-exports from @parsec@
     , ParseError
     -- * Instruction and InstructionPos helpers
-    , Language.Docker.Syntax.instruction
     , Language.Docker.EDSL.instructionPos
-    , Language.Docker.Syntax.sourcename
     ) where
 
 import qualified Control.Monad.IO.Class

--- a/src/Language/Docker.hs
+++ b/src/Language/Docker.hs
@@ -60,8 +60,8 @@ module Language.Docker
     , Language.Docker.Syntax.Tag
     , Language.Docker.Syntax.Ports
     , Language.Docker.Syntax.Directory
-    , Language.Docker.Syntax.Source
-    , Language.Docker.Syntax.Destination
+    , Language.Docker.Syntax.SourcePath
+    , Language.Docker.Syntax.TargetPath
     , Language.Docker.Syntax.Arguments
     , Language.Docker.Syntax.Pairs
     , Language.Docker.Syntax.Filename

--- a/src/Language/Docker.hs
+++ b/src/Language/Docker.hs
@@ -60,6 +60,8 @@ module Language.Docker
     , Language.Docker.Syntax.TargetPath(..)
     , Language.Docker.Syntax.Chown(..)
     , Language.Docker.Syntax.CopySource(..)
+    , Language.Docker.Syntax.CopyArgs(..)
+    , Language.Docker.Syntax.AddArgs(..)
     , Language.Docker.Syntax.Image
     , Language.Docker.Syntax.Tag
     , Language.Docker.Syntax.Ports

--- a/src/Language/Docker/EDSL.hs
+++ b/src/Language/Docker/EDSL.hs
@@ -8,6 +8,7 @@ import Control.Monad.Free
 import Control.Monad.Free.TH
 import Control.Monad.Trans.Free (FreeT, iterTM)
 import Control.Monad.Writer
+import Data.List.NonEmpty (NonEmpty)
 import Data.ByteString (ByteString)
 
 import qualified Language.Docker.PrettyPrint as PrettyPrint
@@ -50,11 +51,11 @@ runD (From bi n) =
         EDigestedImage bi' d alias -> runDef Syntax.From (Syntax.DigestedImage bi' d alias) n
 runD (CmdArgs as n) = runDef Syntax.Cmd as n
 runD (Shell as n) = runDef Syntax.Shell as n
-runD (AddArgs s d c n) = runDef (Syntax.Add s d) c n
+runD (AddArgs s d c n) = runDef Syntax.Add (Syntax.AddArgs s d c) n
 runD (User u n) = runDef Syntax.User u n
 runD (Label ps n) = runDef Syntax.Label ps n
 runD (StopSignal s n) = runDef Syntax.Stopsignal s n
-runD (CopyArgs s d c f n) = runDef (Syntax.Copy s d c) f n
+runD (CopyArgs s d c f n) = runDef Syntax.Copy (Syntax.CopyArgs s d c f) n
 runD (RunArgs as n) = runDef Syntax.Run as n
 runD (Workdir d n) = runDef Syntax.Workdir d n
 runD (Expose ps n) = runDef Syntax.Expose ps n
@@ -137,10 +138,10 @@ entrypoint = entrypointArgs . words
 cmd :: MonadFree EInstruction m => String -> m ()
 cmd = cmdArgs . words
 
-copy :: MonadFree EInstruction m => [Syntax.SourcePath] -> Syntax.TargetPath -> m ()
+copy :: MonadFree EInstruction m => NonEmpty Syntax.SourcePath -> Syntax.TargetPath -> m ()
 copy sources dest = copyArgs sources dest Syntax.NoChown Syntax.NoSource
 
-add :: MonadFree EInstruction m => [Syntax.SourcePath] -> Syntax.TargetPath -> m ()
+add :: MonadFree EInstruction m => NonEmpty Syntax.SourcePath -> Syntax.TargetPath -> m ()
 add sources dest = addArgs sources dest Syntax.NoChown
 
 -- | ONBUILD Dockerfile instruction

--- a/src/Language/Docker/EDSL.hs
+++ b/src/Language/Docker/EDSL.hs
@@ -50,11 +50,11 @@ runD (From bi n) =
         EDigestedImage bi' d alias -> runDef Syntax.From (Syntax.DigestedImage bi' d alias) n
 runD (CmdArgs as n) = runDef Syntax.Cmd as n
 runD (Shell as n) = runDef Syntax.Shell as n
-runD (Add s d n) = runDef2 Syntax.Add s d n
+runD (AddArgs s d c n) = runDef (Syntax.Add s d) c n
 runD (User u n) = runDef Syntax.User u n
 runD (Label ps n) = runDef Syntax.Label ps n
 runD (StopSignal s n) = runDef Syntax.Stopsignal s n
-runD (Copy s d n) = runDef2 Syntax.Copy s d n
+runD (CopyArgs s d c f n) = runDef (Syntax.Copy s d c) f n
 runD (RunArgs as n) = runDef Syntax.Run as n
 runD (Workdir d n) = runDef Syntax.Workdir d n
 runD (Expose ps n) = runDef Syntax.Expose ps n
@@ -136,6 +136,12 @@ entrypoint = entrypointArgs . words
 
 cmd :: MonadFree EInstruction m => String -> m ()
 cmd = cmdArgs . words
+
+copy :: MonadFree EInstruction m => [Syntax.SourcePath] -> Syntax.TargetPath -> m ()
+copy sources dest = copyArgs sources dest Syntax.NoChown Syntax.NoSource
+
+add :: MonadFree EInstruction m => [Syntax.SourcePath] -> Syntax.TargetPath -> m ()
+add sources dest = addArgs sources dest Syntax.NoChown
 
 -- | ONBUILD Dockerfile instruction
 --

--- a/src/Language/Docker/EDSL.hs
+++ b/src/Language/Docker/EDSL.hs
@@ -89,7 +89,7 @@ toDockerfile e =
 -- main :: IO ()
 -- main = writeFile "something.dockerfile" $ toDockerfileStr $ do
 --     from (tagged "fpco/stack-build" "lts-6.9")
---     add "." "/app/language-docker"
+--     add ["."] "/app/language-docker"
 --     workdir "/app/language-docker"
 --     run (words "stack build --test --only-dependencies")
 --     cmd (words "stack test")

--- a/src/Language/Docker/EDSL/Types.hs
+++ b/src/Language/Docker/EDSL/Types.hs
@@ -23,18 +23,21 @@ instance IsString EBaseImage where
 data EInstruction next
     = From EBaseImage
            next
-    | Add [Syntax.SourcePath]
-          Syntax.TargetPath
-          next
+    | AddArgs [Syntax.SourcePath]
+              Syntax.TargetPath
+              Syntax.Chown
+              next
     | User String
            next
     | Label Syntax.Pairs
             next
     | StopSignal String
                  next
-    | Copy [Syntax.SourcePath]
-           Syntax.TargetPath
-           next
+    | CopyArgs [Syntax.SourcePath]
+               Syntax.TargetPath
+               Syntax.Chown
+               Syntax.CopySource
+               next
     | RunArgs Syntax.Arguments
               next
     | CmdArgs Syntax.Arguments

--- a/src/Language/Docker/EDSL/Types.hs
+++ b/src/Language/Docker/EDSL/Types.hs
@@ -23,8 +23,8 @@ instance IsString EBaseImage where
 data EInstruction next
     = From EBaseImage
            next
-    | Add Syntax.Source
-          Syntax.Destination
+    | Add [Syntax.SourcePath]
+          Syntax.TargetPath
           next
     | User String
            next
@@ -32,8 +32,8 @@ data EInstruction next
             next
     | StopSignal String
                  next
-    | Copy Syntax.Source
-           Syntax.Destination
+    | Copy [Syntax.SourcePath]
+           Syntax.TargetPath
            next
     | RunArgs Syntax.Arguments
               next

--- a/src/Language/Docker/EDSL/Types.hs
+++ b/src/Language/Docker/EDSL/Types.hs
@@ -3,6 +3,7 @@
 module Language.Docker.EDSL.Types where
 
 import Data.ByteString.Char8 (ByteString)
+import Data.List.NonEmpty (NonEmpty)
 import Data.String
 import qualified Language.Docker.Syntax as Syntax
 
@@ -23,7 +24,7 @@ instance IsString EBaseImage where
 data EInstruction next
     = From EBaseImage
            next
-    | AddArgs [Syntax.SourcePath]
+    | AddArgs (NonEmpty Syntax.SourcePath)
               Syntax.TargetPath
               Syntax.Chown
               next
@@ -33,7 +34,7 @@ data EInstruction next
             next
     | StopSignal String
                  next
-    | CopyArgs [Syntax.SourcePath]
+    | CopyArgs (NonEmpty Syntax.SourcePath)
                Syntax.TargetPath
                Syntax.Chown
                Syntax.CopySource

--- a/src/Language/Docker/Lexer.hs
+++ b/src/Language/Docker/Lexer.hs
@@ -2,7 +2,7 @@ module Language.Docker.Lexer where
 
 import Control.Monad (void)
 import Data.Char
-import Text.Parsec hiding (space, spaces)
+import Text.Parsec hiding (spaces)
 import Text.Parsec.Language (haskell)
 import Text.Parsec.String (Parser)
 import qualified Text.Parsec.Token as Token

--- a/src/Language/Docker/Parser.hs
+++ b/src/Language/Docker/Parser.hs
@@ -9,6 +9,11 @@ import Language.Docker.Lexer
 import Language.Docker.Normalize
 import Language.Docker.Syntax
 
+data CopyFlag
+    = FlagChown Chown
+    | FlagSource CopySource
+    | FlagInvalid String
+
 comment :: Parser Instruction
 comment = do
     void $ char '#'
@@ -67,7 +72,50 @@ cmd = do
 copy :: Parser Instruction
 copy = do
     reserved "COPY"
-    fileList "COPY" Copy
+    flags <- (copyFlag `sepEndBy1` space) <|> return []
+    let chownFlags = [c | FlagChown c <- flags]
+    let sourceFlags = [f | FlagSource f <- flags]
+    let invalid = [i | FlagInvalid i <- flags]
+    -- Let's do some validation on the flags
+    case (invalid, length chownFlags > 1, length sourceFlags > 1) of
+        (i:_, _, _) -> unexpected ("invalid flag " ++ i)
+        (_, True, _) -> unexpected "duplicate flag: --chown"
+        (_, _, True) -> unexpected "duplicate flag: --from"
+        _ -> do
+            let ch =
+                    case chownFlags of
+                        [] -> NoChown
+                        c:_ -> c
+            let fr =
+                    case sourceFlags of
+                        [] -> NoSource
+                        f:_ -> f
+            fileList "COPY" (\src dest -> Copy src dest ch fr)
+
+copyFlag :: Parser CopyFlag
+copyFlag =
+    (FlagChown <$> try chown <?> "only one --chown") <|>
+    (FlagSource <$> try copySource <?> "only one --from") <|>
+    (FlagInvalid <$> try anyFlag <?> "no other flags")
+
+chown :: Parser Chown
+chown = do
+    void $ string "--chown="
+    ch <- many1 (noneOf "\t\n ")
+    return $ Chown ch
+
+copySource :: Parser CopySource
+copySource = do
+    void $ string "--from="
+    src <- many1 (noneOf "\t\n ")
+    return $ CopySource src
+
+anyFlag :: Parser String
+anyFlag = do
+    void $ lookAhead (string "--")
+    void $ string "--"
+    name <- many $ noneOf "\t\n= "
+    return $ "--" ++ name
 
 fileList :: String -> ([SourcePath] -> TargetPath -> Instruction) -> Parser Instruction
 fileList name constr = do
@@ -75,7 +123,7 @@ fileList name constr = do
         (try stringList <?> "an array of strings [\"src_file\", \"dest_file\"]") <|>
         (try spaceSeparated <?> "a space separated list of file paths")
     case paths of
-        [_] -> fail $ "At least two arguments are required for " ++ name
+        [_] -> fail $ "at least two arguments are required for " ++ name
         _ -> return $ constr (SourcePath <$> init paths) (TargetPath $ last paths)
   where
     spaceSeparated = many (noneOf "\t\n ") `sepEndBy1` space
@@ -164,7 +212,12 @@ user = do
 add :: Parser Instruction
 add = do
     reserved "ADD"
-    fileList "ADD" Add
+    flag <- lexeme copyFlag <|> return (FlagChown NoChown)
+    notFollowedBy (string "--") <?> "only the --chown flag or the src and dest paths"
+    case flag of
+        FlagChown ch -> fileList "ADD" (\src dest -> Add src dest ch)
+        FlagSource _ -> unexpected "flag --from"
+        FlagInvalid i -> unexpected ("flag " ++ i)
 
 expose :: Parser Instruction
 expose = do

--- a/src/Language/Docker/Predef.hs
+++ b/src/Language/Docker/Predef.hs
@@ -21,7 +21,6 @@ import qualified System.FilePath.Glob as Glob
 
 import Language.Docker
 import Language.Docker.EDSL.Types
-import Language.Docker.Syntax
 
 appendLnIfMissing :: FilePath -> Text -> IO ()
 appendLnIfMissing fp cts = do

--- a/src/Language/Docker/Predef.hs
+++ b/src/Language/Docker/Predef.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
 
 module Language.Docker.Predef where
 
@@ -9,6 +10,7 @@ import Control.Monad.Free.Class
 import Control.Monad.IO.Class
 import Data.Aeson (Value(..))
 import qualified Data.HashMap.Strict as HashMap
+import Data.List.NonEmpty (fromList)
 import Data.Maybe
 import Data.Monoid
 import Data.Text (Text)
@@ -45,7 +47,9 @@ addGlob pattern dest = do
                     if isdir
                         then (SourcePath $ f <> "/")
                         else (SourcePath f)
-    add fs dest
+    case fs of
+      [] -> return ()
+      _ -> add (fromList fs) dest
 
 copyGlob :: (MonadIO m, MonadFree EInstruction m) => String -> TargetPath -> m ()
 copyGlob = addGlob

--- a/src/Language/Docker/PrettyPrint.hs
+++ b/src/Language/Docker/PrettyPrint.hs
@@ -70,6 +70,10 @@ prettyPrintPort (PortRange start stop) = integer start <> text "-" <> integer st
 prettyPrintPort (Port num TCP) = integer num <> char '/' <> text "tcp"
 prettyPrintPort (Port num UDP) = integer num <> char '/' <> text "udp"
 
+prettyPrintFileList :: [SourcePath] -> TargetPath -> Doc
+prettyPrintFileList sources (TargetPath dest) =
+    hsep $ [text s | SourcePath s <- sources] ++ [text dest]
+
 prettyPrintInstruction :: Instruction -> Doc
 prettyPrintInstruction i =
     case i of
@@ -97,7 +101,9 @@ prettyPrintInstruction i =
         Run c -> do
             text "RUN"
             prettyPrintArguments c
-        Copy s d -> hsep [text "COPY", text s, text d]
+        Copy s d -> do
+            text "COPY"
+            prettyPrintFileList s d
         Cmd c -> do
             text "CMD"
             prettyPrintArguments c
@@ -121,8 +127,7 @@ prettyPrintInstruction i =
             prettyPrintBaseImage b
         Add s d -> do
             text "ADD"
-            text s
-            text d
+            prettyPrintFileList s d
         Shell args -> do
             text "SHELL"
             prettyPrintJSON args

--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving, TypeFamilies #-}
+
 module Language.Docker.Syntax where
 
 import Data.ByteString.Char8 (ByteString)
+import Data.String (IsString)
+import GHC.Exts (IsList(..))
 
 type Image = String
 
@@ -23,11 +27,16 @@ newtype Ports =
     Ports [Port]
     deriving (Show, Eq, Ord)
 
+instance IsList Ports where
+    type Item Ports = Port
+    fromList = Ports
+    toList (Ports ps) = ps
+
 type Directory = String
 
 newtype ImageAlias =
     ImageAlias String
-    deriving (Show, Eq, Ord)
+    deriving (Show, Eq, Ord, IsString)
 
 data BaseImage
     = UntaggedImage Image
@@ -43,9 +52,13 @@ data BaseImage
 -- | Type of the Dockerfile AST
 type Dockerfile = [InstructionPos]
 
-type Source = String
+newtype SourcePath =
+    SourcePath String
+    deriving (Show, Eq, Ord, IsString)
 
-type Destination = String
+newtype TargetPath =
+    TargetPath String
+    deriving (Show, Eq, Ord, IsString)
 
 type Arguments = [String]
 
@@ -54,13 +67,13 @@ type Pairs = [(String, String)]
 -- | All commands available in Dockerfiles
 data Instruction
     = From BaseImage
-    | Add Source
-          Destination
+    | Add [SourcePath]
+          TargetPath
     | User String
     | Label Pairs
     | Stopsignal String
-    | Copy Source
-           Destination
+    | Copy [SourcePath]
+           TargetPath
     | Run Arguments
     | Cmd Arguments
     | Shell Arguments

--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -60,6 +60,16 @@ newtype TargetPath =
     TargetPath String
     deriving (Show, Eq, Ord, IsString)
 
+data Chown
+    = Chown String
+    | NoChown
+    deriving (Show, Eq, Ord)
+
+data CopySource
+    = CopySource String
+    | NoSource
+    deriving (Show, Eq, Ord)
+
 type Arguments = [String]
 
 type Pairs = [(String, String)]
@@ -69,11 +79,14 @@ data Instruction
     = From BaseImage
     | Add [SourcePath]
           TargetPath
+          Chown
     | User String
     | Label Pairs
     | Stopsignal String
     | Copy [SourcePath]
            TargetPath
+           Chown
+           CopySource
     | Run Arguments
     | Cmd Arguments
     | Shell Arguments
@@ -95,14 +108,8 @@ type Linenumber = Int
 
 -- | 'Instruction' with additional location information required for creating
 -- good check messages
-data InstructionPos =
-    InstructionPos Instruction
-                   Filename
-                   Linenumber
-    deriving (Eq, Ord, Show)
-
-instruction :: InstructionPos -> Instruction
-instruction (InstructionPos i _ _) = i
-
-sourcename :: InstructionPos -> Filename
-sourcename (InstructionPos _ fn _) = fn
+data InstructionPos = InstructionPos
+    { instruction :: Instruction
+    , sourcename :: Filename
+    , lineNumber :: Linenumber
+    } deriving (Eq, Ord, Show)

--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -1,8 +1,10 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving, TypeFamilies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, TypeFamilies,
+  DuplicateRecordFields #-}
 
 module Language.Docker.Syntax where
 
 import Data.ByteString.Char8 (ByteString)
+import Data.List.NonEmpty (NonEmpty)
 import Data.String (IsString)
 import GHC.Exts (IsList(..))
 
@@ -23,9 +25,9 @@ data Port
                 Integer
     deriving (Show, Eq, Ord)
 
-newtype Ports =
-    Ports [Port]
-    deriving (Show, Eq, Ord)
+newtype Ports = Ports
+    { unPorts :: [Port]
+    } deriving (Show, Eq, Ord)
 
 instance IsList Ports where
     type Item Ports = Port
@@ -34,9 +36,9 @@ instance IsList Ports where
 
 type Directory = String
 
-newtype ImageAlias =
-    ImageAlias String
-    deriving (Show, Eq, Ord, IsString)
+newtype ImageAlias = ImageAlias
+    { unImageAlias :: String
+    } deriving (Show, Eq, Ord, IsString)
 
 data BaseImage
     = UntaggedImage Image
@@ -52,13 +54,13 @@ data BaseImage
 -- | Type of the Dockerfile AST
 type Dockerfile = [InstructionPos]
 
-newtype SourcePath =
-    SourcePath String
-    deriving (Show, Eq, Ord, IsString)
+newtype SourcePath = SourcePath
+    { unSourcePath :: String
+    } deriving (Show, Eq, Ord, IsString)
 
-newtype TargetPath =
-    TargetPath String
-    deriving (Show, Eq, Ord, IsString)
+newtype TargetPath = TargetPath
+    { unTargetPath :: String
+    } deriving (Show, Eq, Ord, IsString)
 
 data Chown
     = Chown String
@@ -70,6 +72,19 @@ data CopySource
     | NoSource
     deriving (Show, Eq, Ord)
 
+data CopyArgs = CopyArgs
+    { sourcePaths :: NonEmpty SourcePath
+    , targetPath :: TargetPath
+    , chownFlag :: Chown
+    , sourceFlag :: CopySource
+    } deriving (Show, Eq, Ord)
+
+data AddArgs = AddArgs
+    { sourcePaths :: NonEmpty SourcePath
+    , targetPath :: TargetPath
+    , chownFlag :: Chown
+    } deriving (Show, Eq, Ord)
+
 type Arguments = [String]
 
 type Pairs = [(String, String)]
@@ -77,16 +92,11 @@ type Pairs = [(String, String)]
 -- | All commands available in Dockerfiles
 data Instruction
     = From BaseImage
-    | Add [SourcePath]
-          TargetPath
-          Chown
+    | Add AddArgs
     | User String
     | Label Pairs
     | Stopsignal String
-    | Copy [SourcePath]
-           TargetPath
-           Chown
-           CopySource
+    | Copy CopyArgs
     | Run Arguments
     | Cmd Arguments
     | Shell Arguments

--- a/src/Language/Docker/Syntax/Lift.hs
+++ b/src/Language/Docker/Syntax/Lift.hs
@@ -2,11 +2,14 @@
 
 module Language.Docker.Syntax.Lift where
 
+import Data.List.NonEmpty (NonEmpty)
 import Instances.TH.Lift ()
 import Language.Haskell.TH.Lift
 import Language.Haskell.TH.Syntax ()
 
 import Language.Docker.Syntax
+
+deriveLift ''NonEmpty
 
 deriveLift ''Protocol
 
@@ -29,3 +32,7 @@ deriveLift ''TargetPath
 deriveLift ''Chown
 
 deriveLift ''CopySource
+
+deriveLift ''CopyArgs
+
+deriveLift ''AddArgs

--- a/src/Language/Docker/Syntax/Lift.hs
+++ b/src/Language/Docker/Syntax/Lift.hs
@@ -22,3 +22,5 @@ deriveLift ''Instruction
 
 deriveLift ''InstructionPos
 
+deriveLift ''SourcePath
+deriveLift ''TargetPath

--- a/src/Language/Docker/Syntax/Lift.hs
+++ b/src/Language/Docker/Syntax/Lift.hs
@@ -23,4 +23,9 @@ deriveLift ''Instruction
 deriveLift ''InstructionPos
 
 deriveLift ''SourcePath
+
 deriveLift ''TargetPath
+
+deriveLift ''Chown
+
+deriveLift ''CopySource

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.13
+resolver: lts-10.0
 packages:
 - '.'
 flags: {}

--- a/test/Language/Docker/EDSLSpec.hs
+++ b/test/Language/Docker/EDSLSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
 module Language.Docker.EDSLSpec where
 
 import           Control.Monad.IO.Class

--- a/test/Language/Docker/EDSLSpec.hs
+++ b/test/Language/Docker/EDSLSpec.hs
@@ -74,7 +74,7 @@ spec = do
                     fs <- glob "./test/Language/Docker/*.hs"
                     return (map (makeRelative cwd) (sort fs))
                 from "ubuntu"
-                mapM_ (\f -> add f ("/app/" ++ takeFileName f)) fs
+                mapM_ (\f -> add [Syntax.SourcePath f] (Syntax.TargetPath $ "/app/" ++ takeFileName f)) fs
             str `shouldBe` unlines [ "FROM ubuntu"
                                    , "ADD ./test/Language/Docker/EDSLSpec.hs /app/EDSLSpec.hs"
                                    , "ADD ./test/Language/Docker/ExamplesSpec.hs /app/ExamplesSpec.hs"

--- a/test/Language/Docker/ParserSpec.hs
+++ b/test/Language/Docker/ParserSpec.hs
@@ -212,32 +212,32 @@ spec = do
         describe "ADD" $ do
             it "simple ADD" $
                 let file = unlines ["ADD . /app", "ADD http://foo.bar/baz ."]
-                in assertAst file [ Add [SourcePath "."] (TargetPath "/app")
-                                  , Add [SourcePath "http://foo.bar/baz"] (TargetPath ".")
+                in assertAst file [ Add [SourcePath "."] (TargetPath "/app") NoChown
+                                  , Add [SourcePath "http://foo.bar/baz"] (TargetPath ".") NoChown
                                   ]
             it "multifiles ADD" $
                 let file = unlines ["ADD foo bar baz /app"]
-                in assertAst file [ Add (map SourcePath ["foo", "bar", "baz"]) (TargetPath "/app")
+                in assertAst file [ Add (map SourcePath ["foo", "bar", "baz"]) (TargetPath "/app") NoChown
                                   ]
 
             it "list of quoted files" $
                 let file = unlines ["ADD [\"foo\", \"bar\", \"baz\", \"/app\"]"]
-                in assertAst file [ Add (map SourcePath ["foo", "bar", "baz"]) (TargetPath "/app")
+                in assertAst file [ Add (map SourcePath ["foo", "bar", "baz"]) (TargetPath "/app") NoChown
                                   ]
         describe "COPY" $ do
             it "simple COPY" $
                 let file = unlines ["COPY . /app", "COPY baz /some/long/path"]
-                in assertAst file [ Copy [SourcePath "."] (TargetPath "/app")
-                                  , Copy [SourcePath "baz"] (TargetPath "/some/long/path")
+                in assertAst file [ Copy [SourcePath "."] (TargetPath "/app") NoChown NoSource
+                                  , Copy [SourcePath "baz"] (TargetPath "/some/long/path") NoChown NoSource
                                   ]
             it "multifiles COPY" $
                 let file = unlines ["COPY foo bar baz /app"]
-                in assertAst file [ Copy (map SourcePath ["foo", "bar", "baz"]) (TargetPath "/app")
+                in assertAst file [ Copy (map SourcePath ["foo", "bar", "baz"]) (TargetPath "/app") NoChown NoSource
                                   ]
 
             it "list of quoted files" $
                 let file = unlines ["COPY [\"foo\", \"bar\", \"baz\", \"/app\"]"]
-                in assertAst file [ Copy (map SourcePath ["foo", "bar", "baz"]) (TargetPath "/app")
+                in assertAst file [ Copy (map SourcePath ["foo", "bar", "baz"]) (TargetPath "/app") NoChown NoSource
                                   ]
 
 assertAst s ast =


### PR DESCRIPTION
* Better Syntax representation for COPY and ADD
* Support for parsing copy and add flags (`--chown` and `--from`)

Additionally, bumped the `lts` requirement to `lts-10.0` since I really like the error messages and the new compiler speed