### PR TITLE
Correctly parsing comma separated lists

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: language-docker
-version: '8.0.1'
+version: '8.0.2'
 synopsis: Dockerfile parser, pretty-printer and embedded DSL
 description: 'All functions for parsing, printing and writting Dockerfiles are
   exported through @Language.Docker@. For more fine-grained operations look for

--- a/src/Language/Docker/Parser.hs
+++ b/src/Language/Docker/Parser.hs
@@ -83,7 +83,7 @@ natural :: Parser Integer
 natural = L.decimal <?> "positive number"
 
 commaSep :: Parser a -> Parser [a]
-commaSep p = sepBy p (symbol ",")
+commaSep p = sepBy (p <* spaces) (symbol ",")
 
 stringLiteral :: Parser Text
 stringLiteral = do

--- a/test/Language/Docker/ParserSpec.hs
+++ b/test/Language/Docker/ParserSpec.hs
@@ -178,11 +178,15 @@ spec = do
 
         describe "parse CMD" $ do
             it "one line cmd" $ assertAst "CMD true" [Cmd "true"]
+
             it "cmd over several lines" $
                 assertAst "CMD true \\\n && true" [Cmd "true  && true"]
+
             it "quoted command params" $ assertAst "CMD [\"echo\",  \"1\"]" [Cmd ["echo", "1"]]
 
-        describe "parse SHELL" $ do
+            it "Parses commas correctly" $ assertAst "CMD [ \"echo\" ,\"-e\" , \"1\"]" [Cmd ["echo", "-e", "1"]]
+
+        describe "parse SHELL" $
             it "quoted shell params" $
                 assertAst "SHELL [\"/bin/bash\",  \"-c\"]" [Shell ["/bin/bash", "-c"]]
 


### PR DESCRIPTION
It failed before when there were spaces before the comma