### PR TITLE
Add support for escaped quoting

### DIFF
--- a/test/Language/Docker/ParserSpec.hs
+++ b/test/Language/Docker/ParserSpec.hs
@@ -155,6 +155,19 @@ spec = do
                     ast = [ Env [("JAVA_HOME", "C:\\\\jdk1.8.0_112")]
                           ]
                 in assertAst dockerfile ast
+            it "parses env with % in them" $
+                let dockerfile = Text.unlines [ "ENV PHP_FPM_ACCESS_FORMAT=\"prefix \\\"quoted\\\" suffix\""
+                                              ]
+                    ast = [ Env [("PHP_FPM_ACCESS_FORMAT", "%R - %u %t \"%m %r\" %s")]
+                          ]
+                in assertAst dockerfile ast
+
+            it "parses env with % in them" $
+                let dockerfile = Text.unlines [ "ENV PHP_FPM_ACCESS_FORMAT=\"%R - %u %t \\\"%m %r\\\" %s\""
+                                              ]
+                    ast = [ Env [("PHP_FPM_ACCESS_FORMAT", "%R - %u %t \"%m %r\" %s")]
+                          ]
+                in assertAst dockerfile ast
 
         describe "parse RUN" $ do
             it "escaped with space before" $


### PR DESCRIPTION
Ran into an issue with ENV vars and reported it at https://github.com/hadolint/hadolint/issues/428 then dived into why this was happening and found that the actual parsing is done here.

Todo:

- [X] Add tests
- [ ] Fix the issue