### PR TITLE
Fixed parsing of --mount=type=cache

### DIFF
--- a/language-docker.cabal
+++ b/language-docker.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4064f903443322af4bc07da09abc22ee61ae143bfcffb403add7b327cd7b13dd
+-- hash: ead90f9d8a8521aaa2655fc03070f462119ea0218d8ab0aa42c04fc065f55856
 
 name:           language-docker
-version:        9.0.0
+version:        9.1.0
 synopsis:       Dockerfile parser, pretty-printer and embedded DSL
 description:    All functions for parsing and pretty-printing Dockerfiles are exported through @Language.Docker@. For more fine-grained operations look for specific modules that implement a certain functionality.
                 See the <https://github.com/hadolint/language-docker GitHub project> for the source-code and examples.
@@ -26,6 +26,8 @@ license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
     README.md
+    test/fixtures/1.Dockerfile
+    test/fixtures/2.Dockerfile
 
 source-repository head
   type: git
@@ -53,7 +55,7 @@ library
       src
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -fno-warn-unused-do-bind -fno-warn-orphans
   build-depends:
-      base >=4.13 && <5
+      base >=4.8 && <5
     , bytestring >=0.10
     , containers
     , data-default-class
@@ -76,7 +78,7 @@ test-suite hspec
   build-depends:
       HUnit >=1.2
     , QuickCheck
-    , base >=4.13 && <5
+    , base >=4.8 && <5
     , bytestring >=0.10
     , containers
     , data-default-class

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: language-docker
-version: '9.0.1'
+version: '9.1.0'
 synopsis: Dockerfile parser, pretty-printer and embedded DSL
 description: 'All functions for parsing and pretty-printing Dockerfiles are
   exported through @Language.Docker@. For more fine-grained operations look for
@@ -22,6 +22,8 @@ license: GPL-3
 github: hadolint/language-docker
 extra-source-files:
   - README.md
+  - test/fixtures/1.Dockerfile
+  - test/fixtures/2.Dockerfile
 
 dependencies:
   - base >=4.8 && <5

--- a/src/Language/Docker/Parser/Run.hs
+++ b/src/Language/Docker/Parser/Run.hs
@@ -130,10 +130,10 @@ cacheMount args =
     Right as -> return $ foldr cacheOpts def as
   where
     allowed = Set.fromList ["target", "sharing", "id", "ro", "from", "source", "mode", "uid", "gid"]
-    required = Set.fromList ["target", "sharing"]
+    required = Set.singleton "target"
     cacheOpts :: RunMountArg -> CacheOpts -> CacheOpts
     cacheOpts (MountArgTarget path) co = co {cTarget = path}
-    cacheOpts (MountArgSharing sh) co = co {cSharing = sh}
+    cacheOpts (MountArgSharing sh) co = co {cSharing = Just sh}
     cacheOpts (MountArgId i) co = co {cCacheId = Just i}
     cacheOpts (MountArgReadOnly ro) co = co {cReadOnly = Just ro}
     cacheOpts (MountArgFromImage img) co = co {cFromImage = Just img}

--- a/src/Language/Docker/PrettyPrint.hs
+++ b/src/Language/Docker/PrettyPrint.hs
@@ -168,7 +168,7 @@ prettyPrintRunMount (Just mount) = "--mount="
     CacheMount CacheOpts {..} ->
       "type=cache"
         <> printTarget cTarget
-        <> printSharing cSharing
+        <> maybe mempty printSharing cSharing
         <> maybe mempty printId cCacheId
         <> maybe mempty printFromImage cFromImage
         <> maybe mempty printSource cSource

--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -222,7 +222,7 @@ instance Default BindOpts where
 data CacheOpts
   = CacheOpts
       { cTarget :: !TargetPath,
-        cSharing :: !CacheSharing,
+        cSharing :: !(Maybe CacheSharing),
         cCacheId :: !(Maybe Text),
         cReadOnly :: !(Maybe Bool),
         cFromImage :: !(Maybe Text),
@@ -234,7 +234,7 @@ data CacheOpts
   deriving (Show, Eq, Ord)
 
 instance Default CacheOpts where
-  def = CacheOpts "" Shared Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+  def = CacheOpts "" Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 newtype TmpOpts = TmpOpts {tTarget :: TargetPath} deriving (Eq, Show, Ord)
 

--- a/test/Language/Docker/ParserSpec.hs
+++ b/test/Language/Docker/ParserSpec.hs
@@ -479,16 +479,16 @@ spec = do
             file
             [ Run $ RunArgs (ArgumentsText "echo foo") flags
             ]
-    it "--mount=type=cache with target and sharing" $
+    it "--mount=type=cache with target" $
       let file =
             Text.unlines
-              [ "RUN --mount=type=cache,target=/foo,sharing=private echo foo",
-                "RUN --mount=type=cache,target=/bar,sharing=shared echo foo",
-                "RUN --mount=type=cache,target=/baz,sharing=locked echo foo"
+              [ "RUN --mount=type=cache,target=/foo echo foo",
+                "RUN --mount=type=cache,target=/bar echo foo",
+                "RUN --mount=type=cache,target=/baz echo foo"
               ]
-          flags1 = def {mount = Just $ CacheMount (def {cTarget = "/foo", cSharing = Private})}
-          flags2 = def {mount = Just $ CacheMount (def {cTarget = "/bar", cSharing = Shared})}
-          flags3 = def {mount = Just $ CacheMount (def {cTarget = "/baz", cSharing = Locked})}
+          flags1 = def {mount = Just $ CacheMount (def {cTarget = "/foo"})}
+          flags2 = def {mount = Just $ CacheMount (def {cTarget = "/bar"})}
+          flags3 = def {mount = Just $ CacheMount (def {cTarget = "/baz"})}
        in assertAst
             file
             [ Run $ RunArgs (ArgumentsText "echo foo") flags1,
@@ -507,7 +507,7 @@ spec = do
                     CacheMount
                       ( def
                           { cTarget = "/foo",
-                            cSharing = Private,
+                            cSharing = Just Private,
                             cCacheId = Just "a",
                             cReadOnly = Just True,
                             cFromImage = Just "ubuntu",

--- a/test/fixtures/2.Dockerfile
+++ b/test/fixtures/2.Dockerfile
@@ -11,3 +11,6 @@ RUN set -ex; \
 		apt-get install -y --no-install-recommends dirmngr; \
 	fi; \
 	rm -rf /var/lib/apt/lists/*
+
+ONBUILD ENV RUNNER_CMD_EXEC=${RUNNER_CMD_EXEC:-"java \$JAVA_OPTS -jar /runtime/server.jar \$JAR_OPTS"}
+ENV BUNDLE_WITHOUT=${bundle_without:-'development test'}


### PR DESCRIPTION
I had misunderstood that the sharing argument was required, but it is
not.