### PR TITLE
parser: Handle `ARG` instructions without default

### DIFF
--- a/src/Language/Docker/Parser/Instruction.hs
+++ b/src/Language/Docker/Parser/Instruction.hs
@@ -41,8 +41,13 @@ parseArg :: Parser (Instruction Text)
 parseArg = do
   reserved "ARG"
   (try nameWithDefault <?> "the arg name")
+    <|> (try nameWithoutDefault <?> "the arg name")
     <|> Arg <$> untilEol "the argument name" <*> pure Nothing
   where
+    nameWithoutDefault = do
+      name <- someUnless "the argument name" (== '=')
+      void $ untilEol "the rest"
+      return $ Arg name Nothing
     nameWithDefault = do
       name <- someUnless "the argument name" (== '=')
       void $ char '='

--- a/test/Language/Docker/ParserSpec.hs
+++ b/test/Language/Docker/ParserSpec.hs
@@ -31,6 +31,8 @@ spec = do
   describe "parse ARG" $ do
     it "no default" $
       assertAst "ARG FOO" [Arg "FOO" Nothing]
+    it "no default with =" $
+      assertAst "ARG FOO=" [Arg "FOO" Nothing]
     it "with default" $
       assertAst "ARG FOO=bar" [Arg "FOO" (Just "bar")]
   describe "parse FROM" $ do


### PR DESCRIPTION
Improve the parser by correctly handling `ARG` instructions that do not
have a default, but do have a `=`. E.g.:
```
ARG FOO=
```
Previously, the parser would consume all characters until EOL as
argument name in this case, which is wrong, since the `=` sign should
not be part of the argument name in this case.

Fixes https://github.com/hadolint/hadolint/issues/510