### PR TITLE
syntax: add support for --chmod flags   #609

### DIFF
--- a/language-docker.cabal
+++ b/language-docker.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a83a107737af6beacf2202a2f043950007834c140aad6ae9c656b1c983c129bb
+-- hash: fe27a9736c03f8fc0f788082a8a0fb4ce75a857d751022b5dfe325b368f88497
 
 name:           language-docker
 version:        9.2.0
@@ -72,6 +72,7 @@ test-suite hspec
   other-modules:
       Language.Docker.IntegrationSpec
       Language.Docker.ParserSpec
+      Language.Docker.PrettyPrintSpec
       Paths_language_docker
   hs-source-dirs:
       test

--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -128,6 +128,17 @@ instance IsString Chown where
       "" -> NoChown
       _ -> Chown (Text.pack ch)
 
+data Chmod
+  = Chmod !Text
+  | NoChmod
+  deriving (Show, Eq, Ord)
+
+instance IsString Chmod where
+  fromString ch =
+    case ch of
+      "" -> NoChmod
+      _ -> Chmod (Text.pack ch)
+
 data CopySource
   = CopySource !Text
   | NoSource
@@ -156,6 +167,7 @@ data CopyArgs
       { sourcePaths :: NonEmpty SourcePath,
         targetPath :: !TargetPath,
         chownFlag :: !Chown,
+        chmodFlag :: !Chmod,
         sourceFlag :: !CopySource
       }
   deriving (Show, Eq, Ord)
@@ -164,7 +176,8 @@ data AddArgs
   = AddArgs
       { sourcePaths :: NonEmpty SourcePath,
         targetPath :: !TargetPath,
-        chownFlag :: !Chown
+        chownFlag :: !Chown,
+        chmodFlag :: !Chmod
       }
   deriving (Show, Eq, Ord)
 

--- a/test/Language/Docker/PrettyPrintSpec.hs
+++ b/test/Language/Docker/PrettyPrintSpec.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Docker.PrettyPrintSpec where
+
+
+import Data.Default.Class (def)
+import qualified Data.Text as Text
+import Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc.Render.Text
+import Language.Docker.Parser
+import Language.Docker.Syntax
+import Language.Docker.PrettyPrint
+import Test.HUnit hiding (Label)
+import Test.Hspec
+import Text.Megaparsec hiding (Label)
+
+
+spec :: Spec
+spec = do
+  describe "pretty print ADD" $ do
+    it "with just copy" $ do
+      let add = Add
+                  ( AddArgs
+                      [SourcePath "foo"]
+                      (TargetPath "bar")
+                      NoChown
+                      NoChmod
+                  )
+       in assertPretty "ADD foo bar" add
+    it "with just chown" $ do
+      let add = Add
+                  ( AddArgs
+                      [SourcePath "foo"]
+                      (TargetPath "bar")
+                      (Chown "root:root")
+                      NoChmod
+                  )
+       in assertPretty "ADD --chown=root:root foo bar" add
+    it "with just chmod" $ do
+      let add = Add
+                  ( AddArgs
+                      [SourcePath "foo"]
+                      (TargetPath "bar")
+                      NoChown
+                      (Chmod "751")
+                  )
+       in assertPretty "ADD --chmod=751 foo bar" add
+    it "with both chown and chmod" $ do
+      let add = Add
+                  ( AddArgs
+                      [SourcePath "foo"]
+                      (TargetPath "bar")
+                      (Chown "root:root")
+                      (Chmod "751")
+                  )
+       in assertPretty "ADD --chown=root:root --chmod=751 foo bar" add
+  describe "pretty print COPY" $ do
+    it "with just copy" $ do
+      let copy = Copy
+                  ( CopyArgs
+                      [SourcePath "foo"]
+                      (TargetPath "bar")
+                      NoChown
+                      NoChmod
+                      NoSource
+                  )
+       in assertPretty "COPY foo bar" copy
+    it "with just chown" $ do
+      let copy = Copy
+                  ( CopyArgs
+                      [SourcePath "foo"]
+                      (TargetPath "bar")
+                      (Chown "root:root")
+                      NoChmod
+                      NoSource
+                  )
+       in assertPretty "COPY --chown=root:root foo bar" copy
+    it "with just chmod" $ do
+      let copy = Copy
+                  ( CopyArgs
+                      [SourcePath "foo"]
+                      (TargetPath "bar")
+                      NoChown
+                      (Chmod "751")
+                      NoSource
+                  )
+       in assertPretty "COPY --chmod=751 foo bar" copy
+    it "with source baseimage" $ do
+      let copy = Copy
+                  ( CopyArgs
+                      [SourcePath "foo"]
+                      (TargetPath "bar")
+                      NoChown
+                      NoChmod
+                      (CopySource "baseimage")
+                  )
+       in assertPretty "COPY --from=baseimage foo bar" copy
+    it "with both chown and chmod" $ do
+      let copy = Copy
+                  ( CopyArgs
+                      [SourcePath "foo"]
+                      (TargetPath "bar")
+                      (Chown "root:root")
+                      (Chmod "751")
+                      NoSource
+                  )
+       in assertPretty "COPY --chown=root:root --chmod=751 foo bar" copy
+    it "with all three: from, chown and chmod" $ do
+      let copy = Copy
+                  ( CopyArgs
+                      [SourcePath "foo"]
+                      (TargetPath "bar")
+                      (Chown "root:root")
+                      (Chmod "751")
+                      (CopySource "baseimage")
+                  )
+       in assertPretty "COPY --chown=root:root --chmod=751 --from=baseimage foo bar" copy
+
+
+assertPretty :: Text.Text -> Instruction Text.Text -> Assertion
+assertPretty expected instruction = assertEqual
+    "prettyfied instruction not pretty enough"
+    expected
+    (prettyPrintStrict instruction)
+
+prettyPrintStrict :: Instruction Text.Text -> Text.Text
+prettyPrintStrict =
+  renderStrict . layoutPretty (LayoutOptions Unbounded) . prettyPrintInstruction


### PR DESCRIPTION
- add support for the --chmod flag for `ADD`
- add support for the --chmod flag for `COPY`
- add tests for the --chmod flag

Buildkit supports setting a new mode on a file during `COPY`/`ADD`
instructions with the --chmod flag. See: https://github.com/moby/buildkit/pull/1492

fixes: https://github.com/hadolint/hadolint/issues/609