### PR TITLE
parser: handle parser directives

### DIFF
--- a/language-docker.cabal
+++ b/language-docker.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4c166335e4f8bb1979bf3b9b406bb34b47d9c7f6a89f165a58ba5c696e84e54e
+-- hash: 2c9caaab990151b5cf17795136674a3655d2422f22f1e4c84806741c1309e5bd
 
 name:           language-docker
-version:        9.4.0
+version:        10.0.0
 synopsis:       Dockerfile parser, pretty-printer and embedded DSL
 description:    All functions for parsing and pretty-printing Dockerfiles are exported through @Language.Docker@. For more fine-grained operations look for specific modules that implement a certain functionality.
                 See the <https://github.com/hadolint/language-docker GitHub project> for the source-code and examples.
@@ -79,7 +79,7 @@ test-suite hspec
       Paths_language_docker
   hs-source-dirs:
       test
-  default-extensions: OverloadedStrings OverloadedStrings OverloadedLists
+  default-extensions: OverloadedStrings ImplicitParams Rank2Types OverloadedLists
   build-depends:
       HUnit >=1.2
     , QuickCheck

--- a/language-docker.cabal
+++ b/language-docker.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 16d9c4402444a128ff719c0f88b1de7b2465020a9f4a721a18aeebf3ef5f276d
+-- hash: 4c166335e4f8bb1979bf3b9b406bb34b47d9c7f6a89f165a58ba5c696e84e54e
 
 name:           language-docker
-version:        9.3.0
+version:        9.4.0
 synopsis:       Dockerfile parser, pretty-printer and embedded DSL
 description:    All functions for parsing and pretty-printing Dockerfiles are exported through @Language.Docker@. For more fine-grained operations look for specific modules that implement a certain functionality.
                 See the <https://github.com/hadolint/language-docker GitHub project> for the source-code and examples.
@@ -53,6 +53,7 @@ library
       Paths_language_docker
   hs-source-dirs:
       src
+  default-extensions: OverloadedStrings ImplicitParams Rank2Types
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -fno-warn-unused-do-bind -fno-warn-orphans
   build-depends:
       base >=4.8 && <5
@@ -71,11 +72,14 @@ test-suite hspec
   main-is: Spec.hs
   other-modules:
       Language.Docker.IntegrationSpec
+      Language.Docker.ParsePragmaSpec
       Language.Docker.ParserSpec
       Language.Docker.PrettyPrintSpec
+      TestHelper
       Paths_language_docker
   hs-source-dirs:
       test
+  default-extensions: OverloadedStrings OverloadedStrings OverloadedLists
   build-depends:
       HUnit >=1.2
     , QuickCheck

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: language-docker
-version: '9.3.0'
+version: '9.4.0'
 synopsis: Dockerfile parser, pretty-printer and embedded DSL
 description: 'All functions for parsing and pretty-printing Dockerfiles are
   exported through @Language.Docker@. For more fine-grained operations look for
@@ -24,6 +24,8 @@ extra-source-files:
   - README.md
   - test/fixtures/1.Dockerfile
   - test/fixtures/2.Dockerfile
+default-extensions:
+  - OverloadedStrings
 
 dependencies:
   - base >=4.8 && <5
@@ -46,6 +48,9 @@ library:
   - -Wredundant-constraints
   - -fno-warn-unused-do-bind
   - -fno-warn-orphans
+  default-extensions:
+    - ImplicitParams
+    - Rank2Types
   exposed-modules:
   - Language.Docker
   - Language.Docker.Parser
@@ -56,6 +61,9 @@ tests:
   hspec:
     main: Spec.hs
     source-dirs: test
+    default-extensions:
+      - OverloadedStrings
+      - OverloadedLists
     dependencies:
     - hspec
     - QuickCheck

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: language-docker
-version: '9.4.0'
+version: '10.0.0'
 synopsis: Dockerfile parser, pretty-printer and embedded DSL
 description: 'All functions for parsing and pretty-printing Dockerfiles are
   exported through @Language.Docker@. For more fine-grained operations look for
@@ -26,6 +26,8 @@ extra-source-files:
   - test/fixtures/2.Dockerfile
 default-extensions:
   - OverloadedStrings
+  - ImplicitParams
+  - Rank2Types
 
 dependencies:
   - base >=4.8 && <5
@@ -48,9 +50,6 @@ library:
   - -Wredundant-constraints
   - -fno-warn-unused-do-bind
   - -fno-warn-orphans
-  default-extensions:
-    - ImplicitParams
-    - Rank2Types
   exposed-modules:
   - Language.Docker
   - Language.Docker.Parser
@@ -62,7 +61,6 @@ tests:
     main: Spec.hs
     source-dirs: test
     default-extensions:
-      - OverloadedStrings
       - OverloadedLists
     dependencies:
     - hspec

--- a/src/Language/Docker/Parser.hs
+++ b/src/Language/Docker/Parser.hs
@@ -68,6 +68,3 @@ doParse path txt = do
 -- | Changes crlf line endings to simple line endings
 dos2unix :: T.Text -> T.Text
 dos2unix = T.replace "\r\n" "\n"
-
-defaultEsc :: Char
-defaultEsc = '\\'

--- a/src/Language/Docker/Parser/Arguments.hs
+++ b/src/Language/Docker/Parser/Arguments.hs
@@ -8,16 +8,16 @@ import Language.Docker.Parser.Prelude
 import Language.Docker.Syntax
 
 -- Parse arguments of a command in the exec form
-argumentsExec :: Parser (Arguments Text)
+argumentsExec :: (?esc :: Char) => Parser (Arguments Text)
 argumentsExec = do
   args <- brackets $ commaSep stringLiteral
   return $ ArgumentsList (T.unwords args)
 
 -- Parse arguments of a command in the shell form
-argumentsShell :: Parser (Arguments Text)
+argumentsShell :: (?esc :: Char) => Parser (Arguments Text)
 argumentsShell = ArgumentsText <$> toEnd
   where
     toEnd = untilEol "the shell arguments"
 
-arguments :: Parser (Arguments Text)
+arguments :: (?esc :: Char) => Parser (Arguments Text)
 arguments = try argumentsExec <|> try argumentsShell

--- a/src/Language/Docker/Parser/Cmd.hs
+++ b/src/Language/Docker/Parser/Cmd.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Language.Docker.Parser.Cmd
   ( parseCmd,
   )
@@ -9,7 +7,7 @@ import Language.Docker.Parser.Arguments
 import Language.Docker.Parser.Prelude
 import Language.Docker.Syntax
 
-parseCmd :: Parser (Instruction Text)
+parseCmd :: (?esc :: Char) => Parser (Instruction Text)
 parseCmd = do
   reserved "CMD"
   Cmd <$> arguments

--- a/src/Language/Docker/Parser/Expose.hs
+++ b/src/Language/Docker/Parser/Expose.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Language.Docker.Parser.Expose
   ( parseExpose,
   )
@@ -9,19 +7,19 @@ import qualified Data.Text as T
 import Language.Docker.Parser.Prelude
 import Language.Docker.Syntax
 
-parseExpose :: Parser (Instruction Text)
+parseExpose :: (?esc :: Char) => Parser (Instruction Text)
 parseExpose = do
   reserved "EXPOSE"
   Expose <$> ports
 
-port :: Parser Port
+port :: (?esc :: Char) => Parser Port
 port =
   (try portVariable <?> "a variable")
     <|> (try portRange <?> "a port range optionally followed by the protocol (udp/tcp)") -- There a many valid representations of ports
     <|> (try portWithProtocol <?> "a port with its protocol (udp/tcp)")
     <|> (try portInt <?> "a valid port number")
 
-ports :: Parser Ports
+ports :: (?esc :: Char) => Parser Ports
 ports = Ports <$> port `sepEndBy` requiredWhitespace
 
 portRange :: Parser Port
@@ -51,7 +49,7 @@ portWithProtocol = do
   portNumber <- natural
   Port (fromIntegral portNumber) <$> protocol
 
-portVariable :: Parser Port
+portVariable :: (?esc :: Char) => Parser Port
 portVariable = do
   void (char '$')
   variable <- someUnless "the variable name" (== '$')

--- a/src/Language/Docker/Parser/Healthcheck.hs
+++ b/src/Language/Docker/Parser/Healthcheck.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Language.Docker.Parser.Healthcheck
@@ -20,7 +19,7 @@ data CheckFlag
   | FlagRetries Retries
   | CFlagInvalid (Text, Text)
 
-parseHealthcheck :: Parser (Instruction Text)
+parseHealthcheck :: (?esc :: Char) => Parser (Instruction Text)
 parseHealthcheck = do
   reserved "HEALTHCHECK"
   Healthcheck <$> (fullCheck <|> noCheck)
@@ -60,7 +59,7 @@ parseHealthcheck = do
           let retries = listToMaybe retriesD
           return $ Check CheckArgs {..}
 
-checkFlag :: Parser CheckFlag
+checkFlag :: (?esc :: Char) => Parser CheckFlag
 checkFlag =
   (FlagInterval <$> durationFlag "--interval=" <?> "--interval")
     <|> (FlagTimeout <$> durationFlag "--timeout=" <?> "--timeout")
@@ -85,7 +84,7 @@ retriesFlag = do
   n <- try natural <?> "the number of retries"
   return $ Retries (fromIntegral n)
 
-anyFlag :: Parser (Text, Text)
+anyFlag :: (?esc :: Char) => Parser (Text, Text)
 anyFlag = do
   void $ string "--"
   name <- someUnless "the flag value" (== '=')

--- a/src/Language/Docker/PrettyPrint.hs
+++ b/src/Language/Docker/PrettyPrint.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RebindableSyntax #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
@@ -232,6 +231,10 @@ prettyPrintRunSecurity Nothing = mempty
 prettyPrintRunSecurity (Just Sandbox) = "--security=sandbox"
 prettyPrintRunSecurity (Just Insecure) = "--security=insecure"
 
+prettyPrintPragma :: PragmaDirective -> Doc ann
+prettyPrintPragma (Escape (EscapeChar esc)) = "escape = " <> pretty esc
+prettyPrintPragma (Syntax (SyntaxImage img)) = "syntax = " <> prettyPrintImage img
+
 prettyPrintInstruction :: Pretty (Arguments args) => Instruction args -> Doc ann
 prettyPrintInstruction i =
   case i of
@@ -283,6 +286,9 @@ prettyPrintInstruction i =
     User u -> do
       "USER"
       pretty u
+    Pragma p -> do
+      pretty '#'
+      prettyPrintPragma p
     Comment s -> do
       pretty '#'
       pretty s

--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Language.Docker.Syntax where
@@ -16,6 +15,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (DiffTime)
 import GHC.Exts (IsList (..))
+import Text.Printf
 
 data Image
   = Image
@@ -310,6 +310,28 @@ instance IsString (RunArgs Text) where
           mount = Nothing
         }
 
+newtype EscapeChar
+  = EscapeChar
+      { escape :: Char
+      }
+  deriving (Show, Eq, Ord)
+
+instance IsChar EscapeChar where
+  fromChar c =
+    EscapeChar {escape = c}
+  toChar e = escape e
+
+newtype SyntaxImage
+  = SyntaxImage
+      { syntax :: Image
+      }
+  deriving (Show, Eq, Ord)
+
+data PragmaDirective
+  = Escape !EscapeChar
+  | Syntax !SyntaxImage
+  deriving (Show, Eq, Ord)
+
 -- | All commands available in Dockerfiles
 data Instruction args
   = From !BaseImage
@@ -331,6 +353,7 @@ data Instruction args
       !Text
       !(Maybe Text)
   | Healthcheck !(Check args)
+  | Pragma !PragmaDirective
   | Comment !Text
   | OnBuild !(Instruction args)
   deriving (Eq, Ord, Show, Functor)

--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -371,3 +371,6 @@ data InstructionPos args
         lineNumber :: !Linenumber
       }
   deriving (Eq, Ord, Show, Functor)
+
+defaultEsc :: Char
+defaultEsc = '\\'

--- a/test/Language/Docker/IntegrationSpec.hs
+++ b/test/Language/Docker/IntegrationSpec.hs
@@ -4,7 +4,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO
 import qualified Data.Text.Lazy.IO as L
 import Language.Docker.Parser
-import Language.Docker.PrettyPrint (prettyPrint)
+import Language.Docker.PrettyPrint (prettyPrint, prettyPrintDockerfile)
 import Test.HUnit hiding (Label)
 import Test.Hspec
 import Text.Megaparsec hiding (Label)
@@ -41,6 +41,34 @@ spec = do
       case parsed of
         Right a -> L.putStr $ prettyPrint a
         Left err -> assertFailure $ errorBundlePretty err
+
+  describe "escape character detection logic" $ do
+    it "ensure the pretty printer respects escape pragmas" $ do
+      fromDisk <- Data.Text.IO.readFile "test/fixtures/6.Dockerfile"
+      let ast = parseText fromDisk
+       in case ast of
+          Right a ->
+             let fromAst = prettyPrintDockerfile a
+              in assertEqual "error" fromDisk (Text.pack . show $ fromAst)
+          Left err -> assertFailure $ errorBundlePretty err
+
+    it "ensure escape character '\\' is used as default" $ do
+      fromDisk <- Data.Text.IO.readFile "test/fixtures/7.Dockerfile"
+      let ast = parseText fromDisk
+       in case ast of
+          Right a ->
+             let fromAst = prettyPrintDockerfile a
+              in assertEqual "error" fromDisk (Text.pack . show $ fromAst)
+          Left err -> assertFailure $ errorBundlePretty err
+
+    it "ensure the printer ignores escape pragmas in the wrong place" $ do
+      fromDisk <- Data.Text.IO.readFile "test/fixtures/8.Dockerfile"
+      let ast = parseText fromDisk
+       in case ast of
+          Right a ->
+             let fromAst = prettyPrintDockerfile a
+              in assertEqual "error" fromDisk (Text.pack . show $ fromAst)
+          Left err -> assertFailure $ errorBundlePretty err
 
   describe "parse text" $ do
     it "1.Dockerfile" $ do

--- a/test/Language/Docker/IntegrationSpec.hs
+++ b/test/Language/Docker/IntegrationSpec.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE OverloadedLists #-}
-{-# LANGUAGE OverloadedStrings #-}
-
 module Language.Docker.IntegrationSpec where
 
 import qualified Data.Text as Text
@@ -14,30 +11,94 @@ import Text.Megaparsec hiding (Label)
 
 spec :: Spec
 spec = do
-  describe "first" $ do
-    it "no erors" $ do
+  describe "parse file" $ do
+    it "1.Dockerfile" $ do
       parsed <- parseFile "test/fixtures/1.Dockerfile"
       case parsed of
         Right a -> L.putStr $ prettyPrint a
         Left err -> assertFailure $ errorBundlePretty err
 
-  describe "second" $ do
-    it "no erors" $ do
+    it "2.Dockerfile" $ do
       parsed <- parseFile "test/fixtures/2.Dockerfile"
       case parsed of
         Right a -> L.putStr $ prettyPrint a
         Left err -> assertFailure $ errorBundlePretty err
 
-  describe "first clrf" $ do
-    it "no erors" $ do
+    it "3.Dockerfile" $ do
+      parsed <- parseFile "test/fixtures/3.Dockerfile"
+      case parsed of
+        Right a -> L.putStr $ prettyPrint a
+        Left err -> assertFailure $ errorBundlePretty err
+
+    it "4.Dockerfile" $ do
+      parsed <- parseFile "test/fixtures/4.Dockerfile"
+      case parsed of
+        Right a -> L.putStr $ prettyPrint a
+        Left err -> assertFailure $ errorBundlePretty err
+
+    it "5.Dockerfile" $ do
+      parsed <- parseFile "test/fixtures/5.Dockerfile"
+      case parsed of
+        Right a -> L.putStr $ prettyPrint a
+        Left err -> assertFailure $ errorBundlePretty err
+
+  describe "parse text" $ do
+    it "1.Dockerfile" $ do
       contents <- Data.Text.IO.readFile "test/fixtures/1.Dockerfile"
       case parseText (Text.replace "\n" "\r\n" contents) of
         Right _ -> return ()
         Left err -> assertFailure $ errorBundlePretty err
 
-  describe "second clrf" $ do
-    it "no erors" $ do
+    it "2.Dockerfile" $ do
       contents <- Data.Text.IO.readFile "test/fixtures/2.Dockerfile"
+      case parseText contents of
+        Right _ -> return ()
+        Left err -> assertFailure $ errorBundlePretty err
+
+    it "3.Dockerfile" $ do
+      contents <- Data.Text.IO.readFile "test/fixtures/3.Dockerfile"
+      case parseText contents of
+        Right _ -> return ()
+        Left err -> assertFailure $ errorBundlePretty err
+
+    it "4.Dockerfile" $ do
+      contents <- Data.Text.IO.readFile "test/fixtures/4.Dockerfile"
+      case parseText contents of
+        Right _ -> return ()
+        Left err -> assertFailure $ errorBundlePretty err
+
+    it "5.Dockerfile" $ do
+      contents <- Data.Text.IO.readFile "test/fixtures/5.Dockerfile"
+      case parseText contents of
+        Right _ -> return ()
+        Left err -> assertFailure $ errorBundlePretty err
+
+    it "1.Dockerfile crlf" $ do
+      contents <- Data.Text.IO.readFile "test/fixtures/1.Dockerfile"
+      case parseText contents of
+        Right _ -> return ()
+        Left err -> assertFailure $ errorBundlePretty err
+
+    it "2.Dockerfile crlf" $ do
+      contents <- Data.Text.IO.readFile "test/fixtures/2.Dockerfile"
+      case parseText (Text.replace "\n" "\r\n" contents) of
+        Right _ -> return ()
+        Left err -> assertFailure $ errorBundlePretty err
+
+    it "3.Dockerfile crlf" $ do
+      contents <- Data.Text.IO.readFile "test/fixtures/3.Dockerfile"
+      case parseText (Text.replace "\n" "\r\n" contents) of
+        Right _ -> return ()
+        Left err -> assertFailure $ errorBundlePretty err
+
+    it "4.Dockerfile crlf" $ do
+      contents <- Data.Text.IO.readFile "test/fixtures/4.Dockerfile"
+      case parseText (Text.replace "\n" "\r\n" contents) of
+        Right _ -> return ()
+        Left err -> assertFailure $ errorBundlePretty err
+
+    it "5.Dockerfile crlf" $ do
+      contents <- Data.Text.IO.readFile "test/fixtures/5.Dockerfile"
       case parseText (Text.replace "\n" "\r\n" contents) of
         Right _ -> return ()
         Left err -> assertFailure $ errorBundlePretty err

--- a/test/Language/Docker/ParsePragmaSpec.hs
+++ b/test/Language/Docker/ParsePragmaSpec.hs
@@ -1,0 +1,73 @@
+module Language.Docker.ParsePragmaSpec where
+
+import qualified Data.Text as Text
+import Language.Docker.Parser
+import Language.Docker.Syntax
+import TestHelper
+import Test.HUnit hiding (Label)
+import Test.Hspec
+
+
+spec :: Spec
+spec = do
+  describe "parse # pragma" $ do
+    it "# escape = \\" $
+      let dockerfile = Text.unlines ["# escape = \\\\"]  -- this need double escaping for some reason.
+       in assertAst dockerfile [Pragma (Escape EscapeChar {escape = '\\'})]
+    it "#escape=`" $
+      let dockerfile = Text.unlines ["#escape=`"]
+       in assertAst dockerfile [Pragma (Escape EscapeChar {escape = '`'})]
+    it "# escape=`" $
+      let dockerfile = Text.unlines ["# escape=`"]
+       in assertAst dockerfile [Pragma (Escape EscapeChar {escape = '`'})]
+    it "#escape =`" $
+      let dockerfile = Text.unlines ["#escape =`"]
+       in assertAst dockerfile [Pragma (Escape EscapeChar {escape = '`'})]
+    it "#escape= `" $
+      let dockerfile = Text.unlines ["#escape= `"]
+       in assertAst dockerfile [Pragma (Escape EscapeChar {escape = '`'})]
+    it "# escape =`" $
+      let dockerfile = Text.unlines ["# escape =`"]
+       in assertAst dockerfile [Pragma (Escape EscapeChar {escape = '`'})]
+    it "#escape = `" $
+      let dockerfile = Text.unlines ["#escape = `"]
+       in assertAst dockerfile [Pragma (Escape EscapeChar {escape = '`'})]
+    it "# escape = `" $
+      let dockerfile = Text.unlines ["# escape = `"]
+       in assertAst dockerfile [Pragma (Escape EscapeChar {escape = '`'})]
+    it "# Escape = `" $
+      let dockerfile = Text.unlines ["# escape = `"]
+       in assertAst dockerfile [Pragma (Escape EscapeChar {escape = '`'})]
+    it "# ESCAPE = `" $
+      let dockerfile = Text.unlines ["# escape = `"]
+       in assertAst dockerfile [Pragma (Escape EscapeChar {escape = '`'})]
+    it "#syntax=docker/dockerfile:1.0" $
+      let dockerfile = Text.unlines ["#syntax=docker/dockerfile:1.0"]
+       in assertAst dockerfile [Pragma (Syntax SyntaxImage {syntax = "docker/dockerfile:1.0"})]
+    it "# syntax=docker/dockerfile:1.0" $
+      let dockerfile = Text.unlines ["# syntax=docker/dockerfile:1.0"]
+       in assertAst dockerfile [Pragma (Syntax SyntaxImage {syntax = "docker/dockerfile:1.0"})]
+    it "#syntax =docker/dockerfile:1.0" $
+      let dockerfile = Text.unlines ["#syntax =docker/dockerfile:1.0"]
+       in assertAst dockerfile [Pragma (Syntax SyntaxImage {syntax = "docker/dockerfile:1.0"})]
+    it "#syntax= docker/dockerfile:1.0" $
+      let dockerfile = Text.unlines ["#syntax= docker/dockerfile:1.0"]
+       in assertAst dockerfile [Pragma (Syntax SyntaxImage {syntax = "docker/dockerfile:1.0"})]
+    it "# syntax =docker/dockerfile:1.0" $
+      let dockerfile = Text.unlines ["# syntax =docker/dockerfile:1.0"]
+       in assertAst dockerfile [Pragma (Syntax SyntaxImage {syntax = "docker/dockerfile:1.0"})]
+    it "#syntax = docker/dockerfile:1.0" $
+      let dockerfile = Text.unlines ["#syntax = docker/dockerfile:1.0"]
+       in assertAst dockerfile [Pragma (Syntax SyntaxImage {syntax = "docker/dockerfile:1.0"})]
+    it "# syntax= docker/dockerfile:1.0" $
+      let dockerfile = Text.unlines ["# syntax= docker/dockerfile:1.0"]
+       in assertAst dockerfile [Pragma (Syntax SyntaxImage {syntax = "docker/dockerfile:1.0"})]
+    it "# syntax = docker/dockerfile:1.0" $
+      let dockerfile = Text.unlines ["# syntax = docker/dockerfile:1.0"]
+       in assertAst dockerfile [Pragma (Syntax SyntaxImage {syntax = "docker/dockerfile:1.0"})]
+    it "# Syntax = docker/dockerfile:1.0" $
+      let dockerfile = Text.unlines ["# syntax = docker/dockerfile:1.0"]
+       in assertAst dockerfile [Pragma (Syntax SyntaxImage {syntax = "docker/dockerfile:1.0"})]
+    it "# SYNTAX = docker/dockerfile:1.0" $
+      let dockerfile = Text.unlines ["# syntax = docker/dockerfile:1.0"]
+       in assertAst dockerfile [Pragma (Syntax SyntaxImage {syntax = "docker/dockerfile:1.0"})]

--- a/test/Language/Docker/ParserSpec.hs
+++ b/test/Language/Docker/ParserSpec.hs
@@ -1,30 +1,14 @@
-{-# LANGUAGE OverloadedLists #-}
-{-# LANGUAGE OverloadedStrings #-}
-
 module Language.Docker.ParserSpec where
 
 import Data.Default.Class (def)
 import qualified Data.Text as Text
 import Language.Docker.Parser
 import Language.Docker.Syntax
+import TestHelper
 import Test.HUnit hiding (Label)
 import Test.Hspec
 import Text.Megaparsec hiding (Label)
 
-untaggedImage :: Image -> BaseImage
-untaggedImage n = BaseImage n Nothing Nothing Nothing Nothing
-
-taggedImage :: Image -> Tag -> BaseImage
-taggedImage n t = BaseImage n (Just t) Nothing Nothing Nothing
-
-withDigest :: BaseImage -> Digest -> BaseImage
-withDigest i d = i {digest = Just d}
-
-withAlias :: BaseImage -> ImageAlias -> BaseImage
-withAlias i a = i {alias = Just a}
-
-withPlatform :: BaseImage -> Platform -> BaseImage
-withPlatform i p = i {platform = Just p}
 
 spec :: Spec
 spec = do
@@ -731,9 +715,3 @@ spec = do
             file
             [ Run $ RunArgs (ArgumentsText "echo foo") flags
             ]
-
-assertAst :: HasCallStack => Text.Text -> [Instruction Text.Text] -> Assertion
-assertAst s ast =
-  case parseText s of
-    Left err -> assertFailure $ errorBundlePretty err
-    Right dockerfile -> assertEqual "ASTs are not equal" ast $ map instruction dockerfile

--- a/test/Language/Docker/PrettyPrintSpec.hs
+++ b/test/Language/Docker/PrettyPrintSpec.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedLists #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module Language.Docker.PrettyPrintSpec where
 
@@ -118,7 +116,26 @@ spec = do
                       (CopySource "baseimage")
                   )
        in assertPretty "COPY --chown=root:root --chmod=751 --from=baseimage foo bar" copy
-
+  describe "pretty print # escape" $ do
+    it "# escape = \\" $ do
+      let esc = Pragma (Escape (EscapeChar '\\'))
+       in assertPretty "# escape = \\" esc
+    it "# escape = `" $ do
+      let esc = Pragma (Escape (EscapeChar '`'))
+       in assertPretty "# escape = `" esc
+  describe "pretty print # syntax" $ do
+    it "# syntax = docker/dockerfile:1.0" $ do
+      let img = Pragma
+                  ( Syntax
+                    ( SyntaxImage
+                        ( Image
+                            { registryName = Nothing,
+                              imageName = "docker/dockerfile:1.0"
+                            }
+                        )
+                    )
+                  )
+       in assertPretty "# syntax = docker/dockerfile:1.0" img
 
 assertPretty :: Text.Text -> Instruction Text.Text -> Assertion
 assertPretty expected instruction = assertEqual

--- a/test/Language/Docker/PrettyPrintSpec.hs
+++ b/test/Language/Docker/PrettyPrintSpec.hs
@@ -145,4 +145,7 @@ assertPretty expected instruction = assertEqual
 
 prettyPrintStrict :: Instruction Text.Text -> Text.Text
 prettyPrintStrict =
-  renderStrict . layoutPretty (LayoutOptions Unbounded) . prettyPrintInstruction
+  let ?esc = defaultEsc
+   in renderStrict
+      . layoutPretty (LayoutOptions Unbounded)
+      . prettyPrintInstruction

--- a/test/TestHelper.hs
+++ b/test/TestHelper.hs
@@ -1,0 +1,38 @@
+module TestHelper
+  ( assertAst,
+    taggedImage,
+    withAlias,
+    withDigest,
+    withPlatform,
+    untaggedImage
+  )
+  where
+
+import qualified Data.Text as Text
+import Language.Docker.Parser
+import Language.Docker.Syntax
+import Test.HUnit hiding (Label)
+import Test.Hspec
+import Text.Megaparsec hiding (Label)
+
+
+untaggedImage :: Image -> BaseImage
+untaggedImage n = BaseImage n Nothing Nothing Nothing Nothing
+
+taggedImage :: Image -> Tag -> BaseImage
+taggedImage n t = BaseImage n (Just t) Nothing Nothing Nothing
+
+withDigest :: BaseImage -> Digest -> BaseImage
+withDigest i d = i {digest = Just d}
+
+withAlias :: BaseImage -> ImageAlias -> BaseImage
+withAlias i a = i {alias = Just a}
+
+withPlatform :: BaseImage -> Platform -> BaseImage
+withPlatform i p = i {platform = Just p}
+
+assertAst :: HasCallStack => Text.Text -> [Instruction Text.Text] -> Assertion
+assertAst s ast =
+  case parseText s of
+    Left err -> assertFailure $ errorBundlePretty err
+    Right dockerfile -> assertEqual "ASTs are not equal" ast $ map instruction dockerfile

--- a/test/fixtures/3.Dockerfile
+++ b/test/fixtures/3.Dockerfile
@@ -1,0 +1,6 @@
+# escape = `
+
+FROM debian:10
+
+RUN first cmd `
+ && second cmd

--- a/test/fixtures/4.Dockerfile
+++ b/test/fixtures/4.Dockerfile
@@ -1,0 +1,8 @@
+#syntax=docker/dockerfile:1.0
+# escape = `
+
+FROM debian:10
+
+RUN first cmd `
+ && second cmd `
+ && command C:\some\windows\style\path

--- a/test/fixtures/5.Dockerfile
+++ b/test/fixtures/5.Dockerfile
@@ -1,0 +1,8 @@
+# this will prevent the pragma from taking effect
+#syntax=docker/dockerfile:1.0
+# escape = `
+
+FROM debian:10
+
+RUN first cmd \
+ && second cmd

--- a/test/fixtures/6.Dockerfile
+++ b/test/fixtures/6.Dockerfile
@@ -1,0 +1,3 @@
+# escape = `
+RUN cmd a `
+ && cmd b

--- a/test/fixtures/7.Dockerfile
+++ b/test/fixtures/7.Dockerfile
@@ -1,0 +1,3 @@
+FROM debian:buster
+RUN cmd a \
+ && cmd b

--- a/test/fixtures/8.Dockerfile
+++ b/test/fixtures/8.Dockerfile
@@ -1,0 +1,4 @@
+FROM debian:buster
+# escape = `
+RUN cmd a \
+ && cmd b


### PR DESCRIPTION
- Add handling for parser directives (pragmas) to the parser:
  `escape`, `index`
- Split off tests into separate modules
- Version bump to 9.4.0

See also:
https://docs.docker.com/engine/reference/builder/#parser-directives

fixes: https://github.com/hadolint/hadolint/issues/371
fixes: https://github.com/hadolint/language-docker/issues/48