### PR TITLE
feature: report invalid protocol

### DIFF
--- a/language-docker.cabal
+++ b/language-docker.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: be22c1fce0b44e319fb3f3074bc1842d248590c1834772b7b85f184f88634f45
+-- hash: ab4c06001671d36b01309d824973b5091572cb86d27f7e4eef1201243f07e453
 
 name:           language-docker
 version:        10.0.1
@@ -101,6 +101,7 @@ test-suite hspec
     , containers
     , data-default-class
     , hspec
+    , hspec-megaparsec
     , language-docker
     , megaparsec >=8.0
     , prettyprinter

--- a/package.yaml
+++ b/package.yaml
@@ -70,6 +70,7 @@ tests:
       - OverloadedLists
     dependencies:
     - hspec
+    - hspec-megaparsec
     - QuickCheck
     - language-docker
     - HUnit >=1.2

--- a/src/Language/Docker/Parser/Expose.hs
+++ b/src/Language/Docker/Parser/Expose.hs
@@ -13,11 +13,10 @@ parseExpose = do
   Expose <$> ports
 
 port :: (?esc :: Char) => Parser Port
-port =
-  (try portVariable <?> "a variable")
+port = (try portVariable <?> "a variable")
     <|> (try portRange <?> "a port range optionally followed by the protocol (udp/tcp)") -- There a many valid representations of ports
     <|> (try portWithProtocol <?> "a port with its protocol (udp/tcp)")
-    <|> (try portInt <?> "a valid port number")
+    <|> (portInt <?> "a valid port number")
 
 ports :: (?esc :: Char) => Parser Ports
 ports = Ports <$> port `sepEndBy` requiredWhitespace
@@ -33,7 +32,7 @@ portRange = do
 protocol :: Parser Protocol
 protocol = do
   void (char '/')
-  tcp <|> udp
+  try (tcp <|> udp) <|> fail "invalid protocol"
   where
     tcp = caseInsensitiveString "tcp" >> return TCP
     udp = caseInsensitiveString "udp" >> return UDP

--- a/test/Language/Docker/ParserSpec.hs
+++ b/test/Language/Docker/ParserSpec.hs
@@ -357,6 +357,9 @@ spec = do
                     ]
                 )
             ]
+    it "should fail with wrong protocol" $
+      let content = "EXPOSE 80/ip"
+       in expectFail content
   describe "syntax" $ do
     it "should handle lowercase instructions (#7 - https://github.com/beijaflor-io/haskell-language-dockerfile/issues/7)" $
       let content = "from ubuntu"

--- a/test/TestHelper.hs
+++ b/test/TestHelper.hs
@@ -1,5 +1,6 @@
 module TestHelper
   ( assertAst,
+    expectFail,
     taggedImage,
     withAlias,
     withDigest,
@@ -13,6 +14,7 @@ import Language.Docker.Parser
 import Language.Docker.Syntax
 import Test.HUnit hiding (Label)
 import Test.Hspec
+import Test.Hspec.Megaparsec
 import Text.Megaparsec hiding (Label)
 
 
@@ -36,3 +38,7 @@ assertAst s ast =
   case parseText s of
     Left err -> assertFailure $ errorBundlePretty err
     Right dockerfile -> assertEqual "ASTs are not equal" ast $ map instruction dockerfile
+
+expectFail :: HasCallStack => Text.Text -> Assertion
+expectFail input =
+  parseText `shouldFailOn` input


### PR DESCRIPTION
Propagate the correct error message `invalid protocol` upwards in case
parsing an expose expression fails because a wrong protocol was
specified.

fixes: https://github.com/hadolint/hadolint/issues/675