### PR TITLE
workflow: Add linting and unit testing

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,58 @@
+# Runs on pull requests against master, and on master branch
+
+name: Haskell Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches: [ master ]
+    paths:
+      - '.github/workflows/haskell.yml'
+      - 'stack*.yaml'
+      - 'hadolint.cabal'
+      - 'src/**'
+      - 'test/**'
+
+jobs:
+  hadolint:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: macos-latest
+        - os: ubuntu-latest
+        - os: windows-latest
+
+    steps:
+
+    # setup:
+
+    - name: Check out
+      uses: actions/checkout@v2
+
+
+    - name: Setup Haskell
+      id: setup-haskell-cabal
+      uses: haskell/actions/setup@v1
+      with:
+          ghc-version: '8.10'
+
+    - name: Freeze
+      run: cabal freeze
+
+    # cache
+
+    - name: Cache store
+      uses: actions/cache@v2.1.6
+      with:
+        path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+        key: ${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}
+
+    #actions
+
+    - name: Test
+      run: cabal test --enable-tests --test-show-details=direct

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -1,0 +1,32 @@
+# Runs on pull requests against master, and on master branch
+
+name: Haskell Lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches: [ master ]
+    paths:
+      - '.github/workflows/hlint.yml'
+      - 'src/**/*.hs'
+      - 'test/**/*.hs'
+jobs:
+  hlint:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      HLINT_ACTION_LOG_LEVEL: debug
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Set up HLint
+        uses: rwe/actions-hlint-setup@v1
+
+      - name: Haskell Lint
+        uses: rwe/actions-hlint-run@v2
+        with:
+          path: '["src/", "test/", ]'
+          fail-on: warning


### PR DESCRIPTION
- Add linting workflow utilizing `hlint`
- Add unit test workflow utilizing `cabal test`

Given how annoying even a small bug would be in this library, as it would result in a whole lot of version bumping, we should at least run the unit tests we have here against any new code to ensure no breakage happens. Ideally we would build and run Hadolints unit tests as well against any new code, but that would take some more effort to accomplish.
These unit tests are lifted straight from hadolint/hadolint.