### PR TITLE
heredocs: fix parsing bug with line continuations

### DIFF
--- a/language-docker.cabal
+++ b/language-docker.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3b38c6eec0fc0543e696e51fa5a654074e9718ae41bd50f4114824964938c535
+-- hash: f5a50fe92ae4dd5da15e1c9273d27b742ae2ea0d62734a8be7e7a292a0f94571
 
 name:           language-docker
-version:        10.1.0
+version:        10.1.1
 synopsis:       Dockerfile parser, pretty-printer and embedded DSL
 description:    All functions for parsing and pretty-printing Dockerfiles are exported through @Language.Docker@. For more fine-grained operations look for specific modules that implement a certain functionality.
                 See the <https://github.com/hadolint/language-docker GitHub project> for the source-code and examples.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: language-docker
-version: '10.1.0'
+version: '10.1.1'
 synopsis: Dockerfile parser, pretty-printer and embedded DSL
 description: 'All functions for parsing and pretty-printing Dockerfiles are
   exported through @Language.Docker@. For more fine-grained operations look for

--- a/src/Language/Docker/Parser/Prelude.hs
+++ b/src/Language/Docker/Parser/Prelude.hs
@@ -182,7 +182,7 @@ heredocRedirect = do
 
 heredocContent :: Text -> Parser Text
 heredocContent marker = do
-  doc <- manyTill L.charLiteral (string marker)
+  doc <- manyTill anySingle (string marker)
   return $ T.strip $ T.pack doc
 
 heredoc :: Parser Text
@@ -193,7 +193,7 @@ heredoc = do
 -- | Parses text until a heredoc is found. Will also consume the heredoc.
 untilHeredoc :: Parser Text
 untilHeredoc = do
-  txt <- manyTill L.charLiteral heredoc
+  txt <- manyTill anySingle heredoc
   return $ T.strip $ T.pack txt
 
 onlySpaces :: Parser Text

--- a/test/Language/Docker/ParseCopySpec.hs
+++ b/test/Language/Docker/ParseCopySpec.hs
@@ -136,3 +136,9 @@ spec = do
             file
               [ Copy $ CopyArgs [SourcePath "FOO", SourcePath "BAR", SourcePath "FIZZ", SourcePath "BUZZ"] (TargetPath "/target") NoChown NoChmod NoSource
               ]
+    it "foo heredoc with line continuations" $
+      let file = Text.unlines ["COPY <<FOO /target", "foo \\", "bar", "FOO"]
+       in assertAst
+            file
+              [ Copy $ CopyArgs [SourcePath "FOO"] (TargetPath "/target") NoChown NoChmod NoSource
+              ]

--- a/test/Language/Docker/ParseRunSpec.hs
+++ b/test/Language/Docker/ParseRunSpec.hs
@@ -332,3 +332,14 @@ spec = do
       let file = Text.unlines [ "RUN python <<EOF > /file", "print(\"foo\")", "EOF" ]
           flags = def {security = Nothing }
        in assertAst file [ Run $ RunArgs (ArgumentsText "python") flags ]
+    it "heredoc with line continuation" $
+      let file = Text.unlines [ "RUN <<EOF", "apt-get update", "apt-get install foo bar \\", "  buzz bar", "EOF" ]
+          flags = def {security = Nothing }
+       in assertAst
+            file
+            [ Run $ RunArgs
+                      ( ArgumentsText
+                          "apt-get update\napt-get install foo bar \\\n  buzz bar"
+                      )
+                      flags
+            ]


### PR DESCRIPTION
Fix parsing error on line continuation.
The `Text.Megaparsec.Lexer.charLiteral` parser will not parse just any
Char, but will instead make exceptions for escaped characters and
quotes. This resulted in a faulty behaviour when encountering a literal
backslash `\` in a heredoc right before a newline.
The `Text.Megaparsec.anySingle` parsed will instead not make exceptions
for escaped characters and therefore parse the content of a heredoc just
as it is in the input, which is the desired behaviour.

Additionally a test case for the `ADD` and `COPY` instruction has been
added to make sure the parser continues to accept this kind of input.

fixes: https://github.com/hadolint/hadolint/issues/699