### PR TITLE
parser: parser uid/gid in `RUN --mount` as string

### DIFF
--- a/src/Language/Docker/Parser/Run.hs
+++ b/src/Language/Docker/Parser/Run.hs
@@ -20,7 +20,6 @@ data RunFlag
 
 data RunMountArg
   = MountArgFromImage Text
-  | MountArgGid Integer
   | MountArgId Text
   | MountArgMode Text
   | MountArgReadOnly Bool
@@ -29,7 +28,8 @@ data RunMountArg
   | MountArgSource SourcePath
   | MountArgTarget TargetPath
   | MountArgType Text
-  | MountArgUid Integer
+  | MountArgUid Text
+  | MountArgGid Text
   deriving (Show)
 
 data MountType
@@ -241,8 +241,8 @@ cacheSharing =
 mountArgFromImage :: (?esc :: Char) => Parser RunMountArg
 mountArgFromImage = MountArgFromImage <$> key "from" stringArg
 
-mountArgGid :: Parser RunMountArg
-mountArgGid = MountArgGid <$> key "gid" natural
+mountArgGid :: (?esc :: Char) => Parser RunMountArg
+mountArgGid = MountArgGid <$> key "gid" stringArg
 
 mountArgId :: (?esc :: Char) => Parser RunMountArg
 mountArgId = MountArgId <$> key "id" stringArg
@@ -280,8 +280,8 @@ mountArgTarget = do
   label "target=" $ choice [string "target=", string "dst=", string "destination="]
   MountArgTarget . TargetPath <$> stringArg
 
-mountArgUid :: Parser RunMountArg
-mountArgUid = MountArgUid <$> key "uid" natural
+mountArgUid :: (?esc :: Char) => Parser RunMountArg
+mountArgUid = MountArgUid <$> key "uid" stringArg
 
 toArgName :: RunMountArg -> Text
 toArgName (MountArgFromImage _) = "from"

--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -241,8 +241,8 @@ data CacheOpts
         cFromImage :: !(Maybe Text),
         cSource :: !(Maybe SourcePath),
         cMode :: !(Maybe Text),
-        cUid :: !(Maybe Integer),
-        cGid :: !(Maybe Integer)
+        cUid :: !(Maybe Text),
+        cGid :: !(Maybe Text)
       }
   deriving (Show, Eq, Ord)
 
@@ -261,8 +261,8 @@ data SecretOpts
         sIsRequired :: !(Maybe Bool),
         sSource :: !(Maybe SourcePath),
         sMode :: !(Maybe Text),
-        sUid :: !(Maybe Integer),
-        sGid :: !(Maybe Integer)
+        sUid :: !(Maybe Text),
+        sGid :: !(Maybe Text)
       }
   deriving (Eq, Show, Ord)
 

--- a/test/Language/Docker/ParseRunSpec.hs
+++ b/test/Language/Docker/ParseRunSpec.hs
@@ -88,8 +88,8 @@ spec = do
                             cFromImage = Just "ubuntu",
                             cSource = Just "/bar",
                             cMode = Just "0700",
-                            cUid = Just 0,
-                            cGid = Just 0
+                            cUid = Just "0",
+                            cGid = Just "0"
                           }
                       )
               }
@@ -152,8 +152,8 @@ spec = do
                             sIsRequired = Just True,
                             sSource = Just "/bar",
                             sMode = Just "0700",
-                            sUid = Just 0,
-                            sGid = Just 0
+                            sUid = Just "0",
+                            sGid = Just "0"
                           }
                       )
               }
@@ -174,8 +174,8 @@ spec = do
                             sIsRequired = Just True,
                             sSource = Just "/bar",
                             sMode = Just "0700",
-                            sUid = Just 0,
-                            sGid = Just 0
+                            sUid = Just "0",
+                            sGid = Just "0"
                           }
                       )
               }
@@ -196,8 +196,8 @@ spec = do
                             sIsRequired = Just True,
                             sSource = Just "/bar",
                             sMode = Just "0700",
-                            sUid = Just 0,
-                            sGid = Just 0
+                            sUid = Just "0",
+                            sGid = Just "0"
                           }
                       )
               }
@@ -218,8 +218,26 @@ spec = do
                             sIsRequired = Just True,
                             sSource = Just "/bar",
                             sMode = Just "0700",
-                            sUid = Just 0,
-                            sGid = Just 0
+                            sUid = Just "0",
+                            sGid = Just "0"
+                          }
+                      )
+              }
+       in assertAst
+            file
+            [ Run $ RunArgs (ArgumentsText "echo foo") flags
+            ]
+    it "--mount=type=cache uid/gid=$var" $
+      let file = Text.unlines ["RUN --mount=type=cache,target=/foo,uid=$VAR_UID,gid=$VAR_GID echo foo"]
+          flags =
+            def
+              { mount =
+                  Just $
+                    CacheMount
+                      ( def
+                          { cTarget = TargetPath "/foo",
+                            cUid = Just "$VAR_UID",
+                            cGid = Just "$VAR_GID"
                           }
                       )
               }


### PR DESCRIPTION
Parser the uid/gid options in the `--mount` option to the `RUN`
instruction as string. This allows the arguments to those options to be
variables (e.g. build arguments):

```
RUN --mount=type=cache,target=/foo,uid=$UID,gid=$GID echo foo
```

fixes: https://github.com/hadolint/hadolint/issues/705

### Note:
This is a breaking API change.