### PR TITLE
syntax: handle multiple `RUN` mount flags

### DIFF
--- a/language-docker.cabal
+++ b/language-docker.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1819127237c882c67c2cc100efbbd0bdc47dd9b03cf32e6381901974028706ab
+-- hash: 797bec50cbf30bc384022e539dd06b34fb833631112f23eba227db63e7463312
 
 name:           language-docker
-version:        10.2.0
+version:        10.3.0
 synopsis:       Dockerfile parser, pretty-printer and embedded DSL
 description:    All functions for parsing and pretty-printing Dockerfiles are exported through @Language.Docker@. For more fine-grained operations look for specific modules that implement a certain functionality.
                 See the <https://github.com/hadolint/language-docker GitHub project> for the source-code and examples.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: language-docker
-version: '10.2.0'
+version: '10.3.0'
 synopsis: Dockerfile parser, pretty-printer and embedded DSL
 description: 'All functions for parsing and pretty-printing Dockerfiles are
   exported through @Language.Docker@. For more fine-grained operations look for

--- a/src/Language/Docker/Parser/Run.hs
+++ b/src/Language/Docker/Parser/Run.hs
@@ -46,7 +46,7 @@ parseRun = do
 
 runArguments :: (?esc :: Char) => Parser (RunArgs Text)
 runArguments = do
-  presentFlags <- choice [runFlags <* requiredWhitespace, pure (RunFlags Nothing Nothing Nothing)]
+  presentFlags <- choice [runFlags <* requiredWhitespace, pure (RunFlags mempty Nothing Nothing)]
   args <- arguments
   return $ RunArgs args presentFlags
 
@@ -56,8 +56,8 @@ runFlags = do
   return $ foldr toRunFlags emptyFlags flags
   where
     flagSeparator = try (requiredWhitespace *> lookAhead (string "--")) <|> fail "expected flag"
-    emptyFlags = RunFlags Nothing Nothing Nothing
-    toRunFlags (RunFlagMount m) rf = rf {mount = Just m}
+    emptyFlags = RunFlags mempty Nothing Nothing
+    toRunFlags (RunFlagMount m) rf@RunFlags { mount = mnt } = rf {mount = Set.insert m mnt}
     toRunFlags (RunFlagNetwork n) rf = rf {network = Just n}
     toRunFlags (RunFlagSecurity s) rf = rf {security = Just s}
 

--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -12,6 +12,7 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.List.Split (endBy)
 import Data.String (IsString (..))
 import Data.Text (Text)
+import Data.Set (Set)
 import qualified Data.Text as Text
 import Data.Time.Clock (DiffTime)
 import GHC.Exts (IsList (..))
@@ -288,14 +289,14 @@ data RunNetwork
 
 data RunFlags
   = RunFlags
-      { mount :: !(Maybe RunMount),
+      { mount :: !(Set RunMount),
         security :: !(Maybe RunSecurity),
         network :: !(Maybe RunNetwork)
       }
   deriving (Show, Eq, Ord)
 
 instance Default RunFlags where
-  def = RunFlags Nothing Nothing Nothing
+  def = RunFlags mempty Nothing Nothing
 
 data RunArgs args = RunArgs (Arguments args) RunFlags
   deriving (Show, Eq, Ord, Functor)
@@ -305,9 +306,9 @@ instance IsString (RunArgs Text) where
     RunArgs
       (ArgumentsText . Text.pack $ s)
       RunFlags
-        { security = Nothing,
-          network = Nothing,
-          mount = Nothing
+        { mount = mempty,
+          security = Nothing,
+          network = Nothing
         }
 
 newtype EscapeChar


### PR DESCRIPTION
- Add capabilities to handle multiple `RUN` mount flags.
- Bump version to 10.3.0 because this is a breaking change in the API

Sometimes a `RUN` instruction can have multiple `--mount` arguments,
e.g.:

```Dockerfile
RUN --mount=type=cache,target=/var/lib/apt \
    --mount=type=cache,target=/var/cache/apt \
    apt-get update && apt-get install -y foo
```

Previously the AST was limited to handling only one such flag but now a
`Set` of flags is remembered, allowing for multiple mount flags.

This feature is a prerequisite to fixing
https://github.com/hadolint/hadolint/issues/723