### PR TITLE
allow use of host:port in a FROM instruction

### DIFF
--- a/src/Language/Docker/Parser/From.hs
+++ b/src/Language/Docker/Parser/From.hs
@@ -9,11 +9,9 @@ import Language.Docker.Syntax
 
 parseRegistry :: (?esc :: Char) => Parser Registry
 parseRegistry = do
-  domain <- someUnless "a domain name" (== '.')
-  void $ char '.'
-  tld <- someUnless "a TLD" (== '/')
+  registry <- someUnless "a registry" (== '/')
   void $ char '/'
-  return $ Registry (domain <> "." <> tld)
+  return $ Registry (registry)
 
 parsePlatform :: (?esc :: Char) => Parser Platform
 parsePlatform = do

--- a/test/Language/Docker/ParserSpec.hs
+++ b/test/Language/Docker/ParserSpec.hs
@@ -63,6 +63,10 @@ spec = do
       assertAst
         "FROM myregistry.com:5000/imagename:5.12-dev"
         [From (taggedImage (Image (Just "myregistry.com:5000") "imagename") "5.12-dev")]
+    it "parse without '.*' on registry and port and tag" $
+      assertAst
+        "FROM myregistry:5000/imagename:5.12-dev"
+        [From (taggedImage (Image (Just "myregistry.com:5000") "imagename") "5.12-dev")]
     it "Not a registry if no TLD" $
       assertAst
         "FROM myfolder/imagename:5.12-dev"


### PR DESCRIPTION
when having a FROM line like: `FROM myregistry:port/imagename:tag`, there is an error `unexpected ':' expecting '@', a new line followed by the next instruction, at least one space, or the image tag`.
This patch proposes to simplify how the registry is computed.

fixes: https://github.com/hadolint/hadolint/issues/355
    
Note: I don't know haskell, I tested the change by cloning the repo, and testing on a local file using the test in integration-tests