### PR TITLE
heredoc parsing: fix overzealous parsing

### DIFF
--- a/src/Language/Docker/Parser/Prelude.hs
+++ b/src/Language/Docker/Parser/Prelude.hs
@@ -209,10 +209,11 @@ heredoc = do
   m <- heredocMarker
   heredocContent m
 
--- | Parses text until a heredoc is found. Will also consume the heredoc.
+-- | Parses text until a heredoc or newline is found. Will also consume the
+-- heredoc.
 untilHeredoc :: Parser Text
 untilHeredoc = do
-  txt <- manyTill anySingle heredoc
+  txt <- manyTill (anySingleBut '\n') heredoc
   return $ T.strip $ T.pack txt
 
 onlySpaces :: Parser Text


### PR DESCRIPTION
- Fix overzealous parsing of a `RUN` instruction in case later on a
  heredoc follows

A `RUN` instuctions heredoc syntax supports passing the heredoc content
to stdin of a command by writing e.g.
```Dockerfile
RUN command <<EOF
this is a heredoc
EOF
```
In order to parse this command, tokens must be consumed until a heredoc
is encountered. However we must stop and fail the heredoc parser if
before a heredoc marker is encoutered a newline is encountered, because
otherwise this example will mistakenly consume instructions as commands
in the `RUN` instruction:
```Dockerfile
RUN foo bar
FROM newstage  # this instruction would be parsed as if it were a line
               # continuation of `foo bar`
COPY <<EOF /destination.sh
this is a heredoc
EOF
```

fixes: https://github.com/hadolint/hadolint/issues/761