### PR TITLE
parser: fix parsing broken strings in exec format

### DIFF
--- a/language-docker.cabal
+++ b/language-docker.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a57fde3be580edb76aab82767e9e47bbe3cb585d5ea2af07eeb05b5331a5bac8
+-- hash: 7e3c645fe4b97c9aa6b65f9355e3369f3477f15f872e4fab41ad3cdce1dc71f5
 
 name:           language-docker
 version:        10.4.1
@@ -86,6 +86,7 @@ test-suite hspec
   main-is: Spec.hs
   other-modules:
       Language.Docker.IntegrationSpec
+      Language.Docker.ParseCmdSpec
       Language.Docker.ParseCopySpec
       Language.Docker.ParsePragmaSpec
       Language.Docker.ParserSpec

--- a/src/Language/Docker/Parser/Arguments.hs
+++ b/src/Language/Docker/Parser/Arguments.hs
@@ -10,7 +10,7 @@ import Language.Docker.Syntax
 -- Parse arguments of a command in the exec form
 argumentsExec :: (?esc :: Char) => Parser (Arguments Text)
 argumentsExec = do
-  args <- brackets $ commaSep stringLiteral
+  args <- brackets $ commaSep doubleQuotedStringUnescaped
   return $ ArgumentsList (T.unwords args)
 
 -- Parse arguments of a command in the shell form

--- a/src/Language/Docker/Parser/Copy.hs
+++ b/src/Language/Docker/Parser/Copy.hs
@@ -91,7 +91,7 @@ fileList name constr = do
   where
     spaceSeparated =
       someUnless "a file" (== ' ') `sepEndBy1` (try requiredWhitespace <?> "at least another file path")
-    stringList = brackets $ commaSep stringLiteral
+    stringList = brackets $ commaSep doubleQuotedString
 
 unexpectedFlag :: Text -> Text -> Parser a
 unexpectedFlag name "" = customFailure $ NoValueFlagError (T.unpack name)

--- a/src/Language/Docker/Parser/Run.hs
+++ b/src/Language/Docker/Parser/Run.hs
@@ -227,7 +227,7 @@ mountChoices mountType =
         ]
 
 stringArg :: (?esc :: Char) => Parser Text
-stringArg = choice [stringLiteral, someUnless "a string" (== ',')]
+stringArg = choice [doubleQuotedString, someUnless "a string" (== ',')]
 
 key :: Text -> Parser a -> Parser a
 key name p = string (name <> "=") *> p

--- a/test/Language/Docker/ParseCmdSpec.hs
+++ b/test/Language/Docker/ParseCmdSpec.hs
@@ -1,0 +1,37 @@
+module Language.Docker.ParseCmdSpec where
+
+import Data.Default.Class (def)
+import Language.Docker.Parser
+import Language.Docker.Syntax
+import Test.HUnit hiding (Label)
+import Test.Hspec
+import TestHelper
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Set as Set
+import qualified Data.Text as Text
+
+
+spec :: Spec
+spec = do
+  describe "parse CMD instructions" $ do
+    it "one line cmd" $ assertAst "CMD true" [Cmd "true"]
+    it "cmd over several lines" $
+      assertAst "CMD true \\\n && true" [Cmd "true  && true"]
+    it "quoted command params" $ assertAst "CMD [\"echo\",  \"1\"]" [Cmd ["echo", "1"]]
+    it "Parses commas correctly" $ assertAst "CMD [ \"echo\" ,\"-e\" , \"1\"]" [Cmd ["echo", "-e", "1"]]
+
+    -- This is the Dockefile statement under test (cleaned of Haskell escapes):
+    --
+    -- CMD [ "/bin/sh", "-c", \
+    --       "echo foo && \
+    --        echo bar" \
+    --     ]
+    it "parse exec style CMD with long broken lines" $ do
+      let cmd =
+            Text.unlines
+              [ "CMD [ \"/bin/sh\", \"-c\", \\",
+                "      \"echo foo && \\",
+                "       echo bar\" \\",
+                "    ]"
+              ]
+       in assertAst cmd [ Cmd [ "/bin/sh", "-c", "echo foo &&        echo bar" ] ]

--- a/test/Language/Docker/ParserSpec.hs
+++ b/test/Language/Docker/ParserSpec.hs
@@ -174,12 +174,6 @@ spec = do
             [ Env [("PHP_FPM_ACCESS_FORMAT", "%R - %u %t \"%m %r\" %s")]
             ]
        in assertAst dockerfile ast
-  describe "parse CMD" $ do
-    it "one line cmd" $ assertAst "CMD true" [Cmd "true"]
-    it "cmd over several lines" $
-      assertAst "CMD true \\\n && true" [Cmd "true  && true"]
-    it "quoted command params" $ assertAst "CMD [\"echo\",  \"1\"]" [Cmd ["echo", "1"]]
-    it "Parses commas correctly" $ assertAst "CMD [ \"echo\" ,\"-e\" , \"1\"]" [Cmd ["echo", "-e", "1"]]
   describe "parse SHELL" $
     it "quoted shell params" $
       assertAst "SHELL [\"/bin/bash\",  \"-c\"]" [Shell ["/bin/bash", "-c"]]


### PR DESCRIPTION
- Fix parsing of long strings broken into multiple lines in the
  exec/JSON format of CMD, RUN and ENTRYPOINT statements
- Remove legacy alias `stringLiteral` from
  Language.Docker.Parser.Prelude

When specifying a command with arguments in JSON notation (aka. exec
format), sometimes it is useful to break a longer string into several
lines. Although this is not legal JSON syntax, it is supported by Docker
and results are as expected. Therefore the parser should not fail on
these occasions, but rather produce the expected result. In addition to
that the parser needs to remove escaped newlines from the resulting
string.

The legacy alias `stringLiteral` from the Language.Docker.Parser.Prelude
module has been removed, because now there is a difference between
parsing a double quoted string literal as-is or doing so and removing
escaped newlines from the resulting string.

The test suite has been reorganized by moving the tests relating to the
`CMD` statement into their own submodule.

fixes: https://github.com/hadolint/hadolint/issues/783