### PR TITLE
fix: heredocs in lines with escaped newlines

### DIFF
--- a/src/Language/Docker/Parser/Arguments.hs
+++ b/src/Language/Docker/Parser/Arguments.hs
@@ -22,7 +22,7 @@ argumentsShell =
     toEnd = untilEol "the shell arguments"
 
 -- Parse arguments of a command in the heredoc format
-argumentsHeredoc :: Parser (Arguments Text)
+argumentsHeredoc :: (?esc :: Char) => Parser (Arguments Text)
 argumentsHeredoc = ArgumentsText <$> heredoc
 
 arguments :: (?esc :: Char) => Parser (Arguments Text)


### PR DESCRIPTION
Fix parsing error with heredocs within command chains with escaped newlines.

When chaining commands in a `RUN` instructions, it is possible that one of the middle commands takes a heredoc. It is often convenient to also break up the resulting long line with escapes, e.g.:

```Dockerfile
RUN foo \
 && bar <<EOF >> bar.txt \
 && baz
inside heredoc
content
EOF
```

The heredoc parser should not fail on escaped newlines in this command chain.
This requires two modifications:

  - Parsing the rest of the command chain, after a heredoc should not end on the literal '\n' character, but should be done with the `untilEol` parser, which respects the escaped newlins
  - Parsing the command chain before the heredoc requires casting escaped newlines to spaces as to not fail the parser on a '\n' character

This approach works with the caveat that the command chain after the heredoc is ignored and will not end up in the parsed text.

fixes: https://github.com/hadolint/hadolint/issues/923
Signed-off-by: Moritz Röhrich <moritz@ildefons.de>