### PR TITLE
fix: pretty port range with udp and udp

### DIFF
--- a/src/Language/Docker/Syntax/PortRange.hs
+++ b/src/Language/Docker/Syntax/PortRange.hs
@@ -15,6 +15,6 @@ data PortRange
 
 
 instance Pretty PortRange where
+  pretty (PortRange (Port start UDP) (Port end UDP)) = pretty start <> "-" <> pretty end <> "/udp"
   pretty (PortRange (Port start UDP) end) = pretty start <> "-" <> pretty end <> "/udp"
-  pretty (PortRange (PortStr start) (Port end UDP)) = pretty start <> "-" <> pretty end <> "/udp"
   pretty (PortRange start end) = pretty start <> "-" <> pretty end


### PR DESCRIPTION
Pretty print `PortRange` at  ad383b6bcf426930886978bd80ca0e2da5d6028c

```
>> prettyPrintPortSpec $ PortRangeSpec $ PortRange (Port 8080 TCP) (Port 8085 TCP)
8080-8085
>> prettyPrintPortSpec $ PortRangeSpec $ PortRange (Port 8080 TCP) (Port 8085 UDP)
8080-8085/udp
>> prettyPrintPortSpec $ PortRangeSpec $ PortRange (Port 8080 UDP) (Port 8085 TCP)
8080-8085/udp
>> prettyPrintPortSpec $ PortRangeSpec $ PortRange (Port 8080 UDP) (Port 8085 UDP)
8080-8085/udp/udp
```


I think that `PortRange (Port 8080 UDP) (Port 8085 UDP)` is expected pretty print to `8080-8085/udp`.

So fix it.

And removed `(PortRange (PortStr start) (Port end UDP))` case because this case is contained `(PortRange start end)` case. 