### PR TITLE
Add 'ADD --checksum' support

### DIFF
--- a/integration-tests/parse_files.sh
+++ b/integration-tests/parse_files.sh
@@ -77,6 +77,7 @@ function clone_repos() {
     git_clone https://github.com/ArchiveTeam/warrior-dockerfile.git &
     git_clone https://github.com/wckr/wocker-dockerfile.git &
     git_clone https://github.com/kartoza/docker-postgis.git &
+    git_clone https://github.com/andrericardo/docker-subtitleedit &
 
     # colliding names
     git_named_clone https://github.com/yaronr/dockerfile.git yaronr-dockerfile &

--- a/language-docker.cabal
+++ b/language-docker.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 37c989b46891ef750c66b64a1dcbdfc30c1ee22a0ed4821aeb27c7c63c02d2a9
+-- hash: 528820a99687ed9372038487df42e487d63b867ed312d39e8e51b6d1bf4cf7d9
 
 name:           language-docker
-version:        12.1.0
+version:        12.2.0
 synopsis:       Dockerfile parser, pretty-printer and embedded DSL
 description:    All functions for parsing and pretty-printing Dockerfiles are exported through @Language.Docker@. For more fine-grained operations look for specific modules that implement a certain functionality.
                 See the <https://github.com/hadolint/language-docker GitHub project> for the source-code and examples.

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: language-docker
-version: '12.1.0'
+version: '12.2.0'
 synopsis: Dockerfile parser, pretty-printer and embedded DSL
 description: 'All functions for parsing and pretty-printing Dockerfiles are
   exported through @Language.Docker@. For more fine-grained operations look for

--- a/src/Language/Docker/PrettyPrint.hs
+++ b/src/Language/Docker/PrettyPrint.hs
@@ -136,6 +136,12 @@ prettyPrintFileList sources (TargetPath dest) =
           _ -> ""
    in hsep $ [pretty s | SourcePath s <- toList sources] ++ [pretty dest <> ending]
 
+prettyPrintChecksum :: Checksum -> Doc ann
+prettyPrintChecksum checksum =
+  case checksum of
+    Checksum c -> "--checksum=" <> pretty c
+    NoChecksum -> mempty
+
 prettyPrintChown :: Chown -> Doc ann
 prettyPrintChown chown =
   case chown of
@@ -315,8 +321,9 @@ prettyPrintInstruction i =
       prettyPrintBaseImage b
     Add
       AddArgs {sourcePaths, targetPath}
-      AddFlags {chownFlag, chmodFlag, linkFlag} -> do
+      AddFlags {checksumFlag, chownFlag, chmodFlag, linkFlag} -> do
         "ADD"
+        prettyPrintChecksum checksumFlag
         prettyPrintChown chownFlag
         prettyPrintChmod chmodFlag
         prettyPrintLink linkFlag

--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -119,6 +119,17 @@ newtype TargetPath
       }
   deriving (Show, Eq, Ord, IsString)
 
+data Checksum
+  = Checksum !Text
+  | NoChecksum
+  deriving (Show, Eq, Ord)
+
+instance IsString Checksum where
+  fromString ch =
+    case ch of
+      "" -> NoChecksum
+      _ -> Checksum (Text.pack ch)
+
 data Chown
   = Chown !Text
   | NoChown
@@ -197,14 +208,15 @@ data AddArgs
 
 data AddFlags
   = AddFlags
-      { chownFlag :: !Chown,
+      { checksumFlag :: !Checksum,
+        chownFlag :: !Chown,
         chmodFlag :: !Chmod,
         linkFlag :: !Link
       }
   deriving (Show, Eq, Ord)
 
 instance Default AddFlags where
-  def = AddFlags NoChown NoChmod NoLink
+  def = AddFlags NoChecksum NoChown NoChmod NoLink
 
 data Check args
   = Check !(CheckArgs args)

--- a/test/Language/Docker/ParseAddSpec.hs
+++ b/test/Language/Docker/ParseAddSpec.hs
@@ -41,6 +41,14 @@ spec = do
                 )
                 def
             ]
+    it "with checksum flag" $
+       let file = Text.unlines ["ADD --checksum=sha256:24454f830cdd http://www.example.com/foo foo"]
+       in assertAst
+            file
+            [ Add
+                ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
+                ( AddFlags (Chown "root:root") NoChmod NoLink )
+            ]
     it "with chown flag" $
       let file = Text.unlines ["ADD --chown=root:root foo bar"]
        in assertAst
@@ -83,7 +91,7 @@ spec = do
             ]
     it "with all flags" $
       let file =
-            Text.unlines ["ADD --chmod=640 --chown=root:root --link foo bar"]
+            Text.unlines ["ADD --chmod=640 --chown=root:root --checksum=sha256:24454f830cdd --link foo bar"]
        in assertAst
             file
             [ Add

--- a/test/Language/Docker/ParseAddSpec.hs
+++ b/test/Language/Docker/ParseAddSpec.hs
@@ -42,12 +42,12 @@ spec = do
                 def
             ]
     it "with checksum flag" $
-       let file = Text.unlines ["ADD --checksum=sha256:24454f830cdd http://www.example.com/foo foo"]
+       let file = Text.unlines ["ADD --checksum=sha256:24454f830cdd http://www.example.com/foo bar"]
        in assertAst
             file
             [ Add
-                ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags (Chown "root:root") NoChmod NoLink )
+                ( AddArgs (fmap SourcePath ["http://www.example.com/foo"]) (TargetPath "bar") )
+                ( AddFlags (Checksum "sha256:24454f830cdd") NoChown NoChmod NoLink )
             ]
     it "with chown flag" $
       let file = Text.unlines ["ADD --chown=root:root foo bar"]
@@ -55,7 +55,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags (Chown "root:root") NoChmod NoLink )
+                ( AddFlags NoChecksum (Chown "root:root") NoChmod NoLink )
             ]
     it "with chmod flag" $
       let file = Text.unlines ["ADD --chmod=640 foo bar"]
@@ -63,7 +63,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChown (Chmod "640") NoLink )
+                ( AddFlags NoChecksum NoChown (Chmod "640") NoLink )
             ]
     it "with link flag" $
       let file = Text.unlines ["ADD --link foo bar"]
@@ -71,7 +71,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChown NoChmod Link )
+                ( AddFlags NoChecksum NoChown NoChmod Link )
             ]
     it "with chown and chmod flag" $
       let file = Text.unlines ["ADD --chown=root:root --chmod=640 foo bar"]
@@ -79,7 +79,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags (Chown "root:root") (Chmod "640") NoLink )
+                ( AddFlags NoChecksum (Chown "root:root") (Chmod "640") NoLink )
             ]
     it "with chown and chmod flag other order" $
       let file = Text.unlines ["ADD --chmod=640 --chown=root:root foo bar"]
@@ -87,7 +87,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags (Chown "root:root") (Chmod "640") NoLink )
+                ( AddFlags NoChecksum (Chown "root:root") (Chmod "640") NoLink )
             ]
     it "with all flags" $
       let file =
@@ -96,7 +96,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags (Chown "root:root") (Chmod "640") Link )
+                ( AddFlags (Checksum "sha256:24454f830cdd") (Chown "root:root") (Chmod "640") Link )
             ]
     it "list of quoted files and chown" $
       let file =
@@ -109,5 +109,5 @@ spec = do
                     (fmap SourcePath ["foo", "bar", "baz"])
                     (TargetPath "/app")
                 )
-                ( AddFlags (Chown "user:group") NoChmod NoLink )
+                ( AddFlags NoChecksum (Chown "user:group") NoChmod NoLink )
             ]

--- a/test/Language/Docker/PrettyPrintSpec.hs
+++ b/test/Language/Docker/PrettyPrintSpec.hs
@@ -21,25 +21,30 @@ spec = do
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
                   ( def :: AddFlags )
        in assertPretty "ADD foo bar" add
+    it "with just checksum" $ do
+      let add = Add
+                  ( AddArgs [SourcePath "http://www.example.com/foo"] (TargetPath "bar") )
+                  ( AddFlags ( Checksum "sha256:24454f830cdd" ) NoChown NoChmod NoLink )
+       in assertPretty "ADD --checksum=sha256:24454f830cdd http://www.example.com/foo bar" add
     it "with just chown" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags ( Chown "root:root" ) NoChmod NoLink )
+                  ( AddFlags NoChecksum ( Chown "root:root" ) NoChmod NoLink )
        in assertPretty "ADD --chown=root:root foo bar" add
     it "with just chmod" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChown ( Chmod "751" ) NoLink )
+                  ( AddFlags NoChecksum NoChown ( Chmod "751" ) NoLink )
        in assertPretty "ADD --chmod=751 foo bar" add
     it "with just link" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChown NoChmod Link )
+                  ( AddFlags NoChecksum NoChown NoChmod Link )
        in assertPretty "ADD --link foo bar" add
     it "with chown, chmod and link" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags ( Chown "root:root" ) ( Chmod "751" ) Link )
+                  ( AddFlags NoChecksum ( Chown "root:root" ) ( Chmod "751" ) Link )
        in assertPretty "ADD --chown=root:root --chmod=751 --link foo bar" add
 
   describe "pretty print COPY" $ do


### PR DESCRIPTION
This PR adds support for the `--checksum` flag in the `ADD` instruction:
https://docs.docker.com/engine/reference/builder/#verifying-a-remote-file-checksum-add---checksumchecksum-http-src-dest

Note, I know nothing about the Haskell programming language - I have written this by looking at this other PR https://github.com/hadolint/language-docker/pull/84. So please be kind!

Final goal would be to add another rule to Hadolint recommending the use of `ADD --checksum` with remote sources.