### PR TITLE
Language.Docker: enable DuplicateRecordFields to fix build error with ghc-9.8.x

### DIFF
--- a/src/Language/Docker.hs
+++ b/src/Language/Docker.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+
 module Language.Docker
   ( Language.Docker.Syntax.Dockerfile,
 


### PR DESCRIPTION
~~~
src/Language/Docker.hs:26:5: error: [GHC-97219]
    Duplicate record field ‘sourcePaths’ in export list:
       ‘Language.Docker.Syntax.AddArgs(..)’ exports the field ‘Language.Docker.Syntax.sourcePaths’
       belonging to the constructor ‘Language.Docker.Syntax.AddArgs’
         imported qualified from ‘Language.Docker.Syntax’ at src/Language/Docker.hs:46:1-39
         (and originally defined at src/Language/Docker/Syntax.hs:193:9-19)
       ‘Language.Docker.Syntax.CopyArgs(..)’ exports the field ‘Language.Docker.Syntax.sourcePaths’
       belonging to the constructor ‘Language.Docker.Syntax.CopyArgs’
         imported qualified from ‘Language.Docker.Syntax’ at src/Language/Docker.hs:46:1-39
         (and originally defined at src/Language/Docker/Syntax.hs:174:9-19)
~~~

Fixes https://github.com/hadolint/language-docker/issues/93.