### PR TITLE
feat: add env argument for secret mounts

### DIFF
--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -297,6 +297,7 @@ data SecretOpts
         sCacheId :: !(Maybe Text),
         sIsRequired :: !(Maybe Bool),
         sSource :: !(Maybe SourcePath),
+        sEnv :: !(Maybe Text),
         sMode :: !(Maybe Text),
         sUid :: !(Maybe Text),
         sGid :: !(Maybe Text)
@@ -304,7 +305,7 @@ data SecretOpts
   deriving (Eq, Show, Ord)
 
 instance Default SecretOpts where
-  def = SecretOpts Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+  def = SecretOpts Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 data CacheSharing
   = Shared

--- a/test/Language/Docker/ParseRunSpec.hs
+++ b/test/Language/Docker/ParseRunSpec.hs
@@ -186,7 +186,7 @@ spec = do
             [ Run $ RunArgs (ArgumentsText "echo foo") flags
             ]
     it "--mount=type=secret all modifiers" $
-      let file = Text.unlines ["RUN --mount=type=secret,target=/foo,id=a,required,source=/bar,mode=0700,uid=0,gid=0 echo foo"]
+      let file = Text.unlines ["RUN --mount=type=secret,target=/foo,env=baz,id=a,required,source=/bar,mode=0700,uid=0,gid=0 echo foo"]
           flags =
             def
               { mount =
@@ -194,6 +194,7 @@ spec = do
                     SecretMount
                       ( def
                           { sTarget = Just "/foo",
+                            sEnv = Just "baz",
                             sCacheId = Just "a",
                             sIsRequired = Just True,
                             sSource = Just "/bar",
@@ -208,7 +209,7 @@ spec = do
             [ Run $ RunArgs (ArgumentsText "echo foo") flags
             ]
     it "--mount=type=secret all modifiers, required explicit" $
-      let file = Text.unlines ["RUN --mount=type=secret,target=/foo,id=a,required=true,source=/bar,mode=0700,uid=0,gid=0 echo foo"]
+      let file = Text.unlines ["RUN --mount=type=secret,target=/foo,env=baz,id=a,required=true,source=/bar,mode=0700,uid=0,gid=0 echo foo"]
           flags =
             def
               { mount =
@@ -216,6 +217,7 @@ spec = do
                     SecretMount
                       ( def
                           { sTarget = Just "/foo",
+                            sEnv = Just "baz",
                             sCacheId = Just "a",
                             sIsRequired = Just True,
                             sSource = Just "/bar",


### PR DESCRIPTION
This change add the support of the `env` arguments in mount of type "secret" introduced since Dockerfile v1.10.0. 

Ref: https://docs.docker.com/reference/dockerfile/#run---mounttypesecret

Ref https://github.com/hadolint/hadolint/issues/1039