### PR TITLE
Add support for the --exclude flag

### DIFF
--- a/src/Language/Docker/PrettyPrint.hs
+++ b/src/Language/Docker/PrettyPrint.hs
@@ -288,12 +288,13 @@ prettyPrintInstruction i =
       prettyPrintArguments c
     Copy
       CopyArgs {sourcePaths, targetPath}
-      CopyFlags {chmodFlag, chownFlag, linkFlag, sourceFlag} -> do
+      CopyFlags {chmodFlag, chownFlag, linkFlag, sourceFlag, excludeFlags} -> do
         "COPY"
         prettyPrintChown chownFlag
         prettyPrintChmod chmodFlag
         prettyPrintLink linkFlag
         prettyPrintCopySource sourceFlag
+        prettyPrintExcludes excludeFlags
         prettyPrintFileList sourcePaths targetPath
     Cmd c -> do
       "CMD"
@@ -321,12 +322,13 @@ prettyPrintInstruction i =
       prettyPrintBaseImage b
     Add
       AddArgs {sourcePaths, targetPath}
-      AddFlags {checksumFlag, chownFlag, chmodFlag, linkFlag} -> do
+      AddFlags {checksumFlag, chownFlag, chmodFlag, linkFlag, excludeFlags} -> do
         "ADD"
         prettyPrintChecksum checksumFlag
         prettyPrintChown chownFlag
         prettyPrintChmod chmodFlag
         prettyPrintLink linkFlag
+        prettyPrintExcludes excludeFlags
         prettyPrintFileList sourcePaths targetPath
     Shell args -> do
       "SHELL"
@@ -342,6 +344,12 @@ prettyPrintInstruction i =
       prettyPrintArguments checkCommand
   where
     (>>) = spaceCat
+
+prettyPrintExcludes :: [Exclude] -> Doc ann
+prettyPrintExcludes excludes = hsep (fmap prettyPrintExclude excludes)
+
+prettyPrintExclude :: Exclude -> Doc ann
+prettyPrintExclude (Exclude e) = "--exclude=" <> pretty e
 
 spaceCat :: Doc ann -> Doc ann -> Doc ann
 spaceCat a Empty = a

--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -192,12 +192,13 @@ data CopyFlags
       { chownFlag :: !Chown,
         chmodFlag :: !Chmod,
         linkFlag :: !Link,
-        sourceFlag :: !CopySource
+        sourceFlag :: !CopySource,
+        excludeFlags :: ![Exclude]
       }
   deriving (Show, Eq, Ord)
 
 instance Default CopyFlags where
-  def = CopyFlags NoChown NoChmod NoLink NoSource
+  def = CopyFlags NoChown NoChmod NoLink NoSource []
 
 data AddArgs
   = AddArgs
@@ -211,12 +212,19 @@ data AddFlags
       { checksumFlag :: !Checksum,
         chownFlag :: !Chown,
         chmodFlag :: !Chmod,
-        linkFlag :: !Link
+        linkFlag :: !Link,
+        excludeFlags :: ![Exclude]
       }
   deriving (Show, Eq, Ord)
 
 instance Default AddFlags where
-  def = AddFlags NoChecksum NoChown NoChmod NoLink
+  def = AddFlags NoChecksum NoChown NoChmod NoLink []
+
+newtype Exclude
+  = Exclude
+      { unExclude :: Text
+      }
+  deriving (Show, Eq, Ord, IsString)
 
 data Check args
   = Check !(CheckArgs args)

--- a/test/Language/Docker/ParseAddSpec.hs
+++ b/test/Language/Docker/ParseAddSpec.hs
@@ -111,3 +111,27 @@ spec = do
                 )
                 ( AddFlags NoChecksum (Chown "user:group") NoChmod NoLink )
             ]
+    it "with exclude flag" $
+      let file = Text.unlines ["ADD --exclude=*.tmp foo bar"]
+       in assertAst
+            file
+            [ Add
+                ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
+                ( AddFlags NoChecksum NoChown NoChmod NoLink (Exclude "*.tmp") )
+            ]
+    it "with multiple exclude flags" $
+      let file = Text.unlines ["ADD --exclude=*.tmp --exclude=*.log foo bar"]
+       in assertAst
+            file
+            [ Add
+                ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
+                ( AddFlags NoChecksum NoChown NoChmod NoLink (Exclude "*.tmp") (Exclude "*.log") )
+            ]
+    it "with exclude and other flags" $
+      let file = Text.unlines ["ADD --chown=root:root --exclude=*.tmp foo bar"]
+       in assertAst
+            file
+            [ Add
+                ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
+                ( AddFlags NoChecksum (Chown "root:root") NoChmod NoLink (Exclude "*.tmp") )
+            ]

--- a/test/Language/Docker/ParseCopySpec.hs
+++ b/test/Language/Docker/ParseCopySpec.hs
@@ -124,6 +124,30 @@ spec = do
                     (CopySource "node")
                 )
             ]
+    it "with exclude flag" $
+      let file = Text.unlines ["COPY --exclude=*.tmp foo bar"]
+       in assertAst
+            file
+            [ Copy
+                ( CopyArgs [ SourcePath "foo" ] (TargetPath "bar") )
+                ( CopyFlags NoChown NoChmod NoLink NoSource [Exclude "*.tmp"] )
+            ]
+    it "with multiple exclude flags" $
+      let file = Text.unlines ["COPY --exclude=*.tmp --exclude=*.log foo bar"]
+       in assertAst
+            file
+            [ Copy
+                ( CopyArgs [ SourcePath "foo" ] (TargetPath "bar") )
+                ( CopyFlags NoChown NoChmod NoLink NoSource [Exclude "*.tmp", Exclude "*.log"] )
+            ]
+    it "with exclude and other flags" $
+      let file = Text.unlines ["COPY --chown=root:root --exclude=*.tmp foo bar"]
+       in assertAst
+            file
+            [ Copy
+                ( CopyArgs [ SourcePath "foo" ] (TargetPath "bar") )
+                ( CopyFlags (Chown "root:root") NoChmod NoLink NoSource [Exclude "*.tmp"] )
+            ]
 
   describe "Copy with Heredocs" $ do
     it "empty heredoc" $

--- a/test/Language/Docker/PrettyPrintSpec.hs
+++ b/test/Language/Docker/PrettyPrintSpec.hs
@@ -46,6 +46,21 @@ spec = do
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
                   ( AddFlags NoChecksum ( Chown "root:root" ) ( Chmod "751" ) Link )
        in assertPretty "ADD --chown=root:root --chmod=751 --link foo bar" add
+    it "with just exclude" $ do
+      let add = Add
+                  ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
+                  ( AddFlags NoChecksum NoChown NoChmod NoLink [Exclude "*.tmp"] )
+       in assertPretty "ADD --exclude=*.tmp foo bar" add
+    it "with multiple exclude flags" $ do
+      let add = Add
+                  ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
+                  ( AddFlags NoChecksum NoChown NoChmod NoLink [Exclude "*.tmp", Exclude "*.log"] )
+       in assertPretty "ADD --exclude=*.tmp --exclude=*.log foo bar" add
+    it "with exclude and other flags" $ do
+      let add = Add
+                  ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
+                  ( AddFlags NoChecksum (Chown "root:root") NoChmod NoLink [Exclude "*.tmp"] )
+       in assertPretty "ADD --chown=root:root --exclude=*.tmp foo bar" add
 
   describe "pretty print COPY" $ do
     it "with just copy" $ do
@@ -95,6 +110,21 @@ spec = do
        in assertPretty
             "COPY --chown=root:root --chmod=751 --link --from=baseimage foo bar"
             copy
+    it "with just exclude" $ do
+      let copy = Copy
+                  ( CopyArgs [SourcePath "foo"] (TargetPath "bar") )
+                  ( CopyFlags NoChown NoChmod NoLink NoSource [Exclude "*.tmp"] )
+       in assertPretty "COPY --exclude=*.tmp foo bar" copy
+    it "with multiple exclude flags" $ do
+      let copy = Copy
+                  ( CopyArgs [SourcePath "foo"] (TargetPath "bar") )
+                  ( CopyFlags NoChown NoChmod NoLink NoSource [Exclude "*.tmp", Exclude "*.log"] )
+       in assertPretty "COPY --exclude=*.tmp --exclude=*.log foo bar" copy
+    it "with exclude and other flags" $ do
+      let copy = Copy
+                  ( CopyArgs [SourcePath "foo"] (TargetPath "bar") )
+                  ( CopyFlags (Chown "root:root") NoChmod NoLink NoSource [Exclude "*.tmp"] )
+       in assertPretty "COPY --chown=root:root --exclude=*.tmp foo bar" copy
 
   describe "pretty print # escape" $ do
     it "# escape = \\" $ do


### PR DESCRIPTION
Hello,

See https://github.com/hadolint/hadolint/issues/1029, https://github.com/hadolint/language-docker/issues/96.

I have absolutely no knowledge about Haskell, so please bear with me 😇 .

Since [Dockerfile 1.7,](https://www.docker.com/blog/new-dockerfile-capabilities-v1-7-0/) the new `--exclude` flag has been added to the `ADD` and `COPY` command. This PR attempts to add the support for this new flag.

Feel free to adapt the PR according to the project standard. I didn't run any test locally, yet.
If this PR is welcomed, I'll add the support for the `--parents` flag as well, in another PR.

Thanks!