### PR TITLE
Add support for SELinux relabeling on bind mounts

### DIFF
--- a/src/Language/Docker/PrettyPrint.hs
+++ b/src/Language/Docker/PrettyPrint.hs
@@ -188,6 +188,7 @@ prettyPrintRunMount set =
             <> maybe mempty printSource bSource
             <> maybe mempty printFromImage bFromImage
             <> maybe mempty printReadOnly bReadOnly
+            <> maybe mempty printRelabel bRelabel
         CacheMount CacheOpts {..} ->
           "type=cache"
             <> printTarget cTarget
@@ -237,6 +238,10 @@ prettyPrintRunMount set =
     printReadOnly False = ",rw"
     printRequired True = ",required"
     printRequired False = mempty
+    printRelabel r = ",relabel="
+      <> case r of
+        RelabelShared -> printQuotable "shared"
+        RelabelPrivate -> printQuotable "private"
 
 prettyPrintRunNetwork :: Maybe RunNetwork -> Doc ann
 prettyPrintRunNetwork Nothing = mempty

--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -119,6 +119,11 @@ newtype TargetPath
       }
   deriving (Show, Eq, Ord, IsString)
 
+data Relabel
+  = RelabelShared
+  | RelabelPrivate
+  deriving (Show, Eq, Ord)
+
 data Checksum
   = Checksum !Text
   | NoChecksum
@@ -271,12 +276,13 @@ data BindOpts
       { bTarget :: !TargetPath,
         bSource :: !(Maybe SourcePath),
         bFromImage :: !(Maybe Text),
-        bReadOnly :: !(Maybe Bool)
+        bReadOnly :: !(Maybe Bool),
+        bRelabel :: !(Maybe Relabel)
       }
   deriving (Show, Eq, Ord)
 
 instance Default BindOpts where
-  def = BindOpts "" Nothing Nothing Nothing
+  def = BindOpts "" Nothing Nothing Nothing Nothing
 
 data CacheOpts
   = CacheOpts

--- a/test/Language/Docker/ParseExposeSpec.hs
+++ b/test/Language/Docker/ParseExposeSpec.hs
@@ -1,7 +1,5 @@
 module Language.Docker.ParseExposeSpec where
 
-import Data.Default.Class (def)
-import qualified Data.Text as Text
 import Language.Docker.Syntax
 import TestHelper
 import Test.Hspec

--- a/test/Language/Docker/ParseHealthcheckSpec.hs
+++ b/test/Language/Docker/ParseHealthcheckSpec.hs
@@ -1,10 +1,8 @@
 module Language.Docker.ParseHealthcheckSpec where
 
-import Data.Default.Class (def)
 import Language.Docker.Syntax
 import Test.Hspec
 import TestHelper
-import qualified Data.Set as Set
 import qualified Data.Text as Text
 
 


### PR DESCRIPTION
Add supprt for SELinux relabeling for bind mounts in the RUN instruction.

See also:
https://github.com/containers/common/blob/crio-1.31/docs/Containerfile.5.md?plain=1#L134C1-L136C72

related-to: hadolint/hadolint#1101