### PR TITLE
basic support for --keep-git-dir, --unpack, --parents

### DIFF
--- a/src/Language/Docker/Parser/Copy.hs
+++ b/src/Language/Docker/Parser/Copy.hs
@@ -14,6 +14,8 @@ data Flag
   | FlagChown Chown
   | FlagChmod Chmod
   | FlagLink Link
+  | FlagKeepGitDir KeepGitDir
+  | FlagParents Parents
   | FlagUnpack Unpack
   | FlagSource CopySource
   | FlagExclude Exclude
@@ -26,16 +28,18 @@ parseCopy = do
   let chownFlags = [c | FlagChown c <- flags]
   let chmodFlags = [c | FlagChmod c <- flags]
   let linkFlags = [l | FlagLink l <- flags]
+  let parentsFlags = [p | FlagParents p <- flags]
   let sourceFlags = [f | FlagSource f <- flags]
   let excludeFlags = [e | FlagExclude e <- flags]
   let invalid = [i | FlagInvalid i <- flags]
   -- Let's do some validation on the flags
-  case (invalid, chownFlags, chmodFlags, linkFlags, sourceFlags, excludeFlags) of
-    ((k, v) : _, _, _, _, _, _) -> unexpectedFlag k v
-    (_, _ : _ : _, _, _, _, _) -> customError $ DuplicateFlagError "--chown"
-    (_, _, _ : _ : _, _, _, _) -> customError $ DuplicateFlagError "--chmod"
-    (_, _, _, _ : _ : _, _, _) -> customError $ DuplicateFlagError "--link"
-    (_, _, _, _, _ : _ : _, _) -> customError $ DuplicateFlagError "--from"
+  case (invalid, chownFlags, chmodFlags, linkFlags, parentsFlags, sourceFlags, excludeFlags) of
+    ((k, v) : _, _, _, _, _, _, _) -> unexpectedFlag k v
+    (_, _ : _ : _, _, _, _, _, _) -> customError $ DuplicateFlagError "--chown"
+    (_, _, _ : _ : _, _, _, _, _) -> customError $ DuplicateFlagError "--chmod"
+    (_, _, _, _ : _ : _, _, _, _) -> customError $ DuplicateFlagError "--link"
+    (_, _, _, _, _ : _ : _, _, _) -> customError $ DuplicateFlagError "--parents"
+    (_, _, _, _, _, _ : _ : _, _) -> customError $ DuplicateFlagError "--from"
     _ -> do
       let cho =
             case chownFlags of
@@ -49,12 +53,16 @@ parseCopy = do
             case linkFlags of
               [] -> NoLink
               l : _ -> l
+      let par =
+            case parentsFlags of
+              [] -> NoParents
+              p : _ -> p
       let fr =
             case sourceFlags of
               [] -> NoSource
               f : _ -> f
-      try (heredocList (\src dest -> Copy (CopyArgs src dest) (CopyFlags cho chm lnk fr excludeFlags)))
-        <|> fileList "COPY" (\src dest -> Copy (CopyArgs src dest) (CopyFlags cho chm lnk fr excludeFlags))
+      try (heredocList (\src dest -> Copy (CopyArgs src dest) (CopyFlags cho chm lnk par fr excludeFlags)))
+        <|> fileList "COPY" (\src dest -> Copy (CopyArgs src dest) (CopyFlags cho chm lnk par fr excludeFlags))
 
 parseAdd :: (?esc :: Char) => Parser (Instruction Text)
 parseAdd = do
@@ -64,18 +72,20 @@ parseAdd = do
   let chownFlags = [c | FlagChown c <- flags]
   let chmodFlags = [c | FlagChmod c <- flags]
   let linkFlags = [l | FlagLink l <- flags]
+  let keepGitDirFlags = [k | FlagKeepGitDir k <- flags]
   let unpackFlags = [u | FlagUnpack u <- flags]
   let excludeFlags = [e | FlagExclude e <- flags]
   let invalidFlags = [i | FlagInvalid i <- flags]
   notFollowedBy (string "--") <?>
-    "only the --checksum, --chown, --chmod, --link, --unpack, --exclude flags or the src and dest paths"
-  case (invalidFlags, checksumFlags, chownFlags, linkFlags, chmodFlags, unpackFlags, excludeFlags) of
-    ((k, v) : _, _, _, _, _, _, _) -> unexpectedFlag k v
-    (_, _ : _ : _, _, _, _, _, _) -> customError $ DuplicateFlagError "--checksum"
-    (_, _, _ : _ : _, _, _, _, _) -> customError $ DuplicateFlagError "--chown"
-    (_, _, _, _ : _ : _, _, _, _) -> customError $ DuplicateFlagError "--chmod"
-    (_, _, _, _, _ : _ : _, _, _) -> customError $ DuplicateFlagError "--link"
-    (_, _, _, _, _, _ : _ : _, _) -> customError $ DuplicateFlagError "--unpack"
+    "only the --checksum, --chown, --chmod, --link, --exclude, --keep-git-dir, --unpack flags or the src and dest paths"
+  case (invalidFlags, checksumFlags, chownFlags, linkFlags, chmodFlags, keepGitDirFlags, unpackFlags, excludeFlags) of
+    ((k, v) : _, _, _, _, _, _, _, _) -> unexpectedFlag k v
+    (_, _ : _ : _, _, _, _, _, _, _) -> customError $ DuplicateFlagError "--checksum"
+    (_, _, _ : _ : _, _, _, _, _, _) -> customError $ DuplicateFlagError "--chown"
+    (_, _, _, _ : _ : _, _, _, _, _) -> customError $ DuplicateFlagError "--chmod"
+    (_, _, _, _, _ : _ : _, _, _, _) -> customError $ DuplicateFlagError "--link"
+    (_, _, _, _, _, _ : _ : _, _, _) -> customError $ DuplicateFlagError "--keep-git-dir"
+    (_, _, _, _, _, _, _ : _ : _, _) -> customError $ DuplicateFlagError "--unpack"
     _ -> do
       let chk = case checksumFlags of
                   [] -> NoChecksum
@@ -89,10 +99,13 @@ parseAdd = do
       let lnk = case linkFlags of
                   [] -> NoLink
                   l : _ -> l
+      let kgd = case keepGitDirFlags of
+                  [] -> NoKeepGitDir
+                  k : _ -> k
       let unp = case unpackFlags of
                   [] -> NoUnpack
                   u : _ -> u
-      fileList "ADD" (\src dest -> Add (AddArgs src dest) (AddFlags chk cho chm lnk unp excludeFlags))
+      fileList "ADD" (\src dest -> Add (AddArgs src dest) (AddFlags chk cho chm lnk kgd unp excludeFlags))
 
 heredocList :: (?esc :: Char) =>
                (NonEmpty SourcePath -> TargetPath -> Instruction Text) ->
@@ -125,13 +138,20 @@ unexpectedFlag name "" = customFailure $ NoValueFlagError (T.unpack name)
 unexpectedFlag name _ = customFailure $ InvalidFlagError (T.unpack name)
 
 copyFlag :: (?esc :: Char) => Parser Flag
-copyFlag = (FlagSource <$> try copySource <?> "only one --from") <|> addFlag
+copyFlag = (FlagSource <$> try copySource <?> "only one --from")
+  <|> (FlagChown <$> try chown <?> "--chown")
+  <|> (FlagChmod <$> try chmod <?> "--chmod")
+  <|> (FlagLink <$> try link <?> "--link")
+  <|> (FlagParents <$> try parents <?> "--parents")
+  <|> (FlagExclude <$> try exclude <?> "--exclude")
+  <|> (FlagInvalid <$> try anyFlag <?> "other flag")
 
 addFlag :: (?esc :: Char) => Parser Flag
 addFlag = (FlagChecksum <$> try checksum <?> "--checksum")
   <|> (FlagChown <$> try chown <?> "--chown")
   <|> (FlagChmod <$> try chmod <?> "--chmod")
   <|> (FlagLink <$> try link <?> "--link")
+  <|> (FlagKeepGitDir <$> try keepGitDir <?> "--keep-git-dir")
   <|> (FlagUnpack <$> try unpack <?> "--unpack")
   <|> (FlagExclude <$> try exclude <?> "--exclude")
   <|> (FlagInvalid <$> try anyFlag <?> "other flag")
@@ -158,6 +178,16 @@ link :: Parser Link
 link = do
   void $ string "--link"
   return Link
+
+parents :: Parser Parents
+parents = do
+  void $ string "--parents"
+  return Parents
+
+keepGitDir :: Parser KeepGitDir
+keepGitDir = do
+  void $ string "--keep-git-dir"
+  return KeepGitDir
 
 unpack :: Parser Unpack
 unpack = do

--- a/src/Language/Docker/Parser/Copy.hs
+++ b/src/Language/Docker/Parser/Copy.hs
@@ -180,20 +180,40 @@ link = do
   return Link
 
 parents :: Parser Parents
-parents = do
-  void $ string "--parents"
-  return Parents
+parents = ( try parentsExplicit <?> "explicit --parents")
+  <|> ( try parentsImplicit <?> "implicit --parents")
+  where
+    parentsExplicit = do
+      void $ string "--parents="
+      val <- string "true" <|> string "false"
+      return $ Parents (val == "true")
+    parentsImplicit = do
+      void $ string "--parents"
+      return $ Parents True
 
 keepGitDir :: Parser KeepGitDir
-keepGitDir = do
-  void $ string "--keep-git-dir"
-  return KeepGitDir
+keepGitDir = ( try keepGitDirExplicit <?> "explicit --keep-git-dir" )
+  <|> ( try keepGitDirImplicit <?> "implicit --keep-git-dir" )
+  where
+    keepGitDirExplicit = do
+      void $ string "--keep-git-dir="
+      val <- string "true" <|> string "false"
+      return $ KeepGitDir (val == "true")
+    keepGitDirImplicit = do
+      void $ string "--keep-git-dir"
+      return $ KeepGitDir True
 
 unpack :: Parser Unpack
-unpack = do
-  void $ string "--unpack="
-  val <- string "true" <|> string "false"
-  return $ Unpack (val == "true")
+unpack = ( try unpackExplicit <?> "explicit --unpack" )
+  <|> ( try unpackImplicit <?> "implicit --unpack" )
+  where
+    unpackExplicit = do
+      void $ string "--unpack="
+      val <- string "true" <|> string "false"
+      return $ Unpack (val == "true")
+    unpackImplicit = do
+      void $ string "--unpack"
+      return $ Unpack True
 
 copySource :: (?esc :: Char) => Parser CopySource
 copySource = do

--- a/src/Language/Docker/PrettyPrint.hs
+++ b/src/Language/Docker/PrettyPrint.hs
@@ -160,6 +160,18 @@ prettyPrintLink link =
     Link -> "--link"
     NoLink -> mempty
 
+prettyPrintKeepGitDir :: KeepGitDir -> Doc ann
+prettyPrintKeepGitDir keepGitDir =
+  case keepGitDir of
+    KeepGitDir -> "--keep-git-dir"
+    NoKeepGitDir -> mempty
+
+prettyPrintParents :: Parents -> Doc ann
+prettyPrintParents parents =
+  case parents of
+    Parents -> "--parents"
+    NoParents -> mempty
+
 prettyPrintUnpack :: Unpack -> Doc ann
 prettyPrintUnpack unpack =
   case unpack of
@@ -300,11 +312,12 @@ prettyPrintInstruction i =
       prettyPrintArguments c
     Copy
       CopyArgs {sourcePaths, targetPath}
-      CopyFlags {chmodFlag, chownFlag, linkFlag, sourceFlag, excludeFlags} -> do
+      CopyFlags {chmodFlag, chownFlag, linkFlag, parentsFlag, sourceFlag, excludeFlags} -> do
         "COPY"
         prettyPrintChown chownFlag
         prettyPrintChmod chmodFlag
         prettyPrintLink linkFlag
+        prettyPrintParents parentsFlag
         prettyPrintCopySource sourceFlag
         prettyPrintExcludes excludeFlags
         prettyPrintFileList sourcePaths targetPath
@@ -334,12 +347,13 @@ prettyPrintInstruction i =
       prettyPrintBaseImage b
     Add
       AddArgs {sourcePaths, targetPath}
-      AddFlags {checksumFlag, chownFlag, chmodFlag, linkFlag, unpackFlag, excludeFlags} -> do
+      AddFlags {checksumFlag, chownFlag, chmodFlag, linkFlag, keepGitDirFlag, unpackFlag, excludeFlags} -> do
         "ADD"
         prettyPrintChecksum checksumFlag
         prettyPrintChown chownFlag
         prettyPrintChmod chmodFlag
         prettyPrintLink linkFlag
+        prettyPrintKeepGitDir keepGitDirFlag
         prettyPrintUnpack unpackFlag
         prettyPrintExcludes excludeFlags
         prettyPrintFileList sourcePaths targetPath

--- a/src/Language/Docker/PrettyPrint.hs
+++ b/src/Language/Docker/PrettyPrint.hs
@@ -163,13 +163,15 @@ prettyPrintLink link =
 prettyPrintKeepGitDir :: KeepGitDir -> Doc ann
 prettyPrintKeepGitDir keepGitDir =
   case keepGitDir of
-    KeepGitDir -> "--keep-git-dir"
+    KeepGitDir True -> "--keep-git-dir=true"
+    KeepGitDir False -> "--keep-git-dir=false"
     NoKeepGitDir -> mempty
 
 prettyPrintParents :: Parents -> Doc ann
 prettyPrintParents parents =
   case parents of
-    Parents -> "--parents"
+    Parents True -> "--parents=true"
+    Parents False -> "--parents=false"
     NoParents -> mempty
 
 prettyPrintUnpack :: Unpack -> Doc ann

--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -162,6 +162,16 @@ data Link
   | NoLink
   deriving (Show, Eq, Ord)
 
+data KeepGitDir
+  = KeepGitDir
+  | NoKeepGitDir
+  deriving (Show, Eq, Ord)
+
+data Parents
+  = Parents
+  | NoParents
+  deriving (Show, Eq, Ord)
+
 data Unpack
   = Unpack !Bool
   | NoUnpack
@@ -202,13 +212,14 @@ data CopyFlags
       { chownFlag :: !Chown,
         chmodFlag :: !Chmod,
         linkFlag :: !Link,
+        parentsFlag :: !Parents,
         sourceFlag :: !CopySource,
         excludeFlags :: ![Exclude]
       }
   deriving (Show, Eq, Ord)
 
 instance Default CopyFlags where
-  def = CopyFlags NoChown NoChmod NoLink NoSource []
+  def = CopyFlags NoChown NoChmod NoLink NoParents NoSource []
 
 data AddArgs
   = AddArgs
@@ -223,13 +234,14 @@ data AddFlags
         chownFlag :: !Chown,
         chmodFlag :: !Chmod,
         linkFlag :: !Link,
+        keepGitDirFlag :: !KeepGitDir,
         unpackFlag :: !Unpack,
         excludeFlags :: ![Exclude]
       }
   deriving (Show, Eq, Ord)
 
 instance Default AddFlags where
-  def = AddFlags NoChecksum NoChown NoChmod NoLink NoUnpack []
+  def = AddFlags NoChecksum NoChown NoChmod NoLink NoKeepGitDir NoUnpack []
 
 newtype Exclude
   = Exclude

--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -163,12 +163,12 @@ data Link
   deriving (Show, Eq, Ord)
 
 data KeepGitDir
-  = KeepGitDir
+  = KeepGitDir !Bool
   | NoKeepGitDir
   deriving (Show, Eq, Ord)
 
 data Parents
-  = Parents
+  = Parents !Bool
   | NoParents
   deriving (Show, Eq, Ord)
 

--- a/test/Language/Docker/ParseAddSpec.hs
+++ b/test/Language/Docker/ParseAddSpec.hs
@@ -47,7 +47,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["http://www.example.com/foo"]) (TargetPath "bar") )
-                ( AddFlags (Checksum "sha256:24454f830cdd") NoChown NoChmod NoLink NoUnpack [] )
+                ( AddFlags (Checksum "sha256:24454f830cdd") NoChown NoChmod NoLink NoKeepGitDir NoUnpack [] )
             ]
     it "with chown flag" $
       let file = Text.unlines ["ADD --chown=root:root foo bar"]
@@ -55,7 +55,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChecksum (Chown "root:root") NoChmod NoLink NoUnpack [] )
+                ( AddFlags NoChecksum (Chown "root:root") NoChmod NoLink NoKeepGitDir NoUnpack [] )
             ]
     it "with chmod flag" $
       let file = Text.unlines ["ADD --chmod=640 foo bar"]
@@ -63,7 +63,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChecksum NoChown (Chmod "640") NoLink NoUnpack [] )
+                ( AddFlags NoChecksum NoChown (Chmod "640") NoLink NoKeepGitDir NoUnpack [] )
             ]
     it "with link flag" $
       let file = Text.unlines ["ADD --link foo bar"]
@@ -71,7 +71,15 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChecksum NoChown NoChmod Link NoUnpack [])
+                ( AddFlags NoChecksum NoChown NoChmod Link NoKeepGitDir NoUnpack [] )
+            ]
+    it "with keep-git-dir flag" $
+      let file = Text.unlines ["ADD --keep-git-dir foo bar"]
+       in assertAst
+            file
+            [ Add
+                ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
+                ( AddFlags NoChecksum NoChown NoChmod NoLink KeepGitDir NoUnpack [] )
             ]
     it "with chown and chmod flag" $
       let file = Text.unlines ["ADD --chown=root:root --chmod=640 foo bar"]
@@ -79,7 +87,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChecksum (Chown "root:root") (Chmod "640") NoLink NoUnpack [] )
+                ( AddFlags NoChecksum (Chown "root:root") (Chmod "640") NoLink NoKeepGitDir NoUnpack [] )
             ]
     it "with chown and chmod flag other order" $
       let file = Text.unlines ["ADD --chmod=640 --chown=root:root foo bar"]
@@ -87,7 +95,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChecksum (Chown "root:root") (Chmod "640") NoLink NoUnpack [] )
+                ( AddFlags NoChecksum (Chown "root:root") (Chmod "640") NoLink NoKeepGitDir NoUnpack [] )
             ]
     it "with all flags" $
       let file =
@@ -96,7 +104,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags (Checksum "sha256:24454f830cdd") (Chown "root:root") (Chmod "640") Link (Unpack True) [] )
+                ( AddFlags (Checksum "sha256:24454f830cdd") (Chown "root:root") (Chmod "640") Link NoKeepGitDir (Unpack True) [] )
             ]
     it "list of quoted files and chown" $
       let file =
@@ -109,7 +117,7 @@ spec = do
                     (fmap SourcePath ["foo", "bar", "baz"])
                     (TargetPath "/app")
                 )
-                ( AddFlags NoChecksum (Chown "user:group") NoChmod NoLink NoUnpack [] )
+                ( AddFlags NoChecksum (Chown "user:group") NoChmod NoLink NoKeepGitDir NoUnpack [] )
             ]
     it "with unpack flag true" $
       let file = Text.unlines ["ADD --unpack=true http://www.example.com/archive.tar.gz /download"]
@@ -117,7 +125,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["http://www.example.com/archive.tar.gz"]) (TargetPath "/download") )
-                ( AddFlags NoChecksum NoChown NoChmod NoLink (Unpack True) [] )
+                ( AddFlags NoChecksum NoChown NoChmod NoLink NoKeepGitDir (Unpack True) [] )
             ]
     it "with unpack flag false" $
       let file = Text.unlines ["ADD --unpack=false my-archive.tar.gz ."]
@@ -125,7 +133,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["my-archive.tar.gz"]) (TargetPath ".") )
-                ( AddFlags NoChecksum NoChown NoChmod NoLink (Unpack False) [] )
+                ( AddFlags NoChecksum NoChown NoChmod NoLink NoKeepGitDir (Unpack False) [] )
             ]
     it "with exclude flag" $
       let file = Text.unlines ["ADD --exclude=*.tmp foo bar"]
@@ -133,7 +141,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChecksum NoChown NoChmod NoLink NoUnpack [Exclude "*.tmp"] )
+                ( AddFlags NoChecksum NoChown NoChmod NoLink NoKeepGitDir NoUnpack [Exclude "*.tmp"] )
             ]
     it "with multiple exclude flags" $
       let file = Text.unlines ["ADD --exclude=*.tmp --exclude=*.log foo bar"]
@@ -141,7 +149,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChecksum NoChown NoChmod NoLink NoUnpack [Exclude "*.tmp", Exclude "*.log"] )
+                ( AddFlags NoChecksum NoChown NoChmod NoLink NoKeepGitDir NoUnpack [Exclude "*.tmp", Exclude "*.log"] )
             ]
     it "with exclude and other flags" $
       let file = Text.unlines ["ADD --chown=root:root --exclude=*.tmp foo bar"]
@@ -149,5 +157,5 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChecksum (Chown "root:root") NoChmod NoLink NoUnpack [Exclude "*.tmp"] )
+                ( AddFlags NoChecksum (Chown "root:root") NoChmod NoLink NoKeepGitDir NoUnpack [Exclude "*.tmp"] )
             ]

--- a/test/Language/Docker/ParseAddSpec.hs
+++ b/test/Language/Docker/ParseAddSpec.hs
@@ -79,8 +79,27 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChecksum NoChown NoChmod NoLink KeepGitDir NoUnpack [] )
+                ( AddFlags NoChecksum NoChown NoChmod NoLink ( KeepGitDir True ) NoUnpack [] )
             ]
+
+    it "with keep-git-dir flag explicit true" $
+      let file = Text.unlines ["ADD --keep-git-dir=true foo bar"]
+       in assertAst
+            file
+            [ Add
+                ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
+                ( AddFlags NoChecksum NoChown NoChmod NoLink ( KeepGitDir True ) NoUnpack [] )
+            ]
+
+    it "with keep-git-dir flag explicit false" $
+      let file = Text.unlines ["ADD --keep-git-dir=false foo bar"]
+       in assertAst
+            file
+            [ Add
+                ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
+                ( AddFlags NoChecksum NoChown NoChmod NoLink ( KeepGitDir False ) NoUnpack [] )
+            ]
+
     it "with chown and chmod flag" $
       let file = Text.unlines ["ADD --chown=root:root --chmod=640 foo bar"]
        in assertAst
@@ -99,7 +118,7 @@ spec = do
             ]
     it "with all flags" $
       let file =
-            Text.unlines ["ADD --chmod=640 --chown=root:root --checksum=sha256:24454f830cdd --link --unpack=true foo bar"]
+            Text.unlines ["ADD --chmod=640 --chown=root:root --checksum=sha256:24454f830cdd --link --unpack foo bar"]
        in assertAst
             file
             [ Add
@@ -119,7 +138,15 @@ spec = do
                 )
                 ( AddFlags NoChecksum (Chown "user:group") NoChmod NoLink NoKeepGitDir NoUnpack [] )
             ]
-    it "with unpack flag true" $
+    it "with unpack flag" $
+      let file = Text.unlines ["ADD --unpack http://www.example.com/archive.tar.gz /download"]
+       in assertAst
+            file
+            [ Add
+                ( AddArgs (fmap SourcePath ["http://www.example.com/archive.tar.gz"]) (TargetPath "/download") )
+                ( AddFlags NoChecksum NoChown NoChmod NoLink NoKeepGitDir (Unpack True) [] )
+            ]
+    it "with unpack flag explicit true" $
       let file = Text.unlines ["ADD --unpack=true http://www.example.com/archive.tar.gz /download"]
        in assertAst
             file
@@ -127,7 +154,7 @@ spec = do
                 ( AddArgs (fmap SourcePath ["http://www.example.com/archive.tar.gz"]) (TargetPath "/download") )
                 ( AddFlags NoChecksum NoChown NoChmod NoLink NoKeepGitDir (Unpack True) [] )
             ]
-    it "with unpack flag false" $
+    it "with unpack flag explicit false" $
       let file = Text.unlines ["ADD --unpack=false my-archive.tar.gz ."]
        in assertAst
             file

--- a/test/Language/Docker/ParseCopySpec.hs
+++ b/test/Language/Docker/ParseCopySpec.hs
@@ -68,7 +68,7 @@ spec = do
             file
             [ Copy
                 ( CopyArgs [ SourcePath "foo" ] (TargetPath "bar") )
-                ( CopyFlags ( Chown "user:group" ) NoChmod NoLink NoSource [])
+                ( CopyFlags ( Chown "user:group" ) NoChmod NoLink NoParents NoSource [])
             ]
     it "with chmod flag" $
       let file = Text.unlines ["COPY --chmod=777 foo bar"]
@@ -76,7 +76,7 @@ spec = do
             file
             [ Copy
                 ( CopyArgs [ SourcePath "foo" ] (TargetPath "bar") )
-                ( CopyFlags NoChown ( Chmod "777" ) NoLink NoSource [])
+                ( CopyFlags NoChown ( Chmod "777" ) NoLink NoParents NoSource [])
             ]
     it "with link flag" $
       let file = Text.unlines [ "COPY --link source /target" ]
@@ -84,7 +84,15 @@ spec = do
             file
             [ Copy
                 ( CopyArgs [ SourcePath "source" ] ( TargetPath "/target" ) )
-                ( CopyFlags NoChown NoChmod Link NoSource [])
+                ( CopyFlags NoChown NoChmod Link NoParents NoSource [])
+            ]
+    it "with parents flag" $
+      let file = Text.unlines [ "COPY --parents source /target" ]
+       in assertAst
+            file
+            [ Copy
+                ( CopyArgs [ SourcePath "source" ] ( TargetPath "/target" ) )
+                ( CopyFlags NoChown NoChmod NoLink Parents NoSource [])
             ]
     it "with from flag" $
       let file = Text.unlines ["COPY --from=node foo bar"]
@@ -92,12 +100,12 @@ spec = do
             file
             [ Copy
                 ( CopyArgs [ SourcePath "foo" ] (TargetPath "bar") )
-                ( CopyFlags NoChown NoChmod NoLink ( CopySource "node" ) [])
+                ( CopyFlags NoChown NoChmod NoLink NoParents ( CopySource "node" ) [])
             ]
     it "with all flags" $
       let file =
             Text.unlines
-              [ "COPY --from=node --chmod=751 --link --chown=user:group foo bar" ]
+              [ "COPY --from=node --chmod=751 --link --chown=user:group --parents foo bar" ]
        in assertAst
             file
             [ Copy
@@ -106,6 +114,7 @@ spec = do
                     (Chown "user:group")
                     (Chmod "751")
                     Link
+                    Parents
                     (CopySource "node")
                     []
                 )
@@ -113,7 +122,7 @@ spec = do
     it "with all flags in different order" $
       let file =
             Text.unlines
-              [ "COPY --link --chown=user:group --from=node --chmod=644 foo bar" ]
+              [ "COPY --link --parents --chown=user:group --from=node --chmod=644 foo bar" ]
        in assertAst
             file
             [ Copy
@@ -122,6 +131,7 @@ spec = do
                     (Chown "user:group")
                     (Chmod "644")
                     Link
+                    Parents
                     (CopySource "node")
                     []
                 )
@@ -132,7 +142,7 @@ spec = do
             file
             [ Copy
                 ( CopyArgs [ SourcePath "foo" ] (TargetPath "bar") )
-                ( CopyFlags NoChown NoChmod NoLink NoSource [Exclude "*.tmp"] )
+                ( CopyFlags NoChown NoChmod NoLink NoParents NoSource [Exclude "*.tmp"] )
             ]
     it "with multiple exclude flags" $
       let file = Text.unlines ["COPY --exclude=*.tmp --exclude=*.log foo bar"]
@@ -140,7 +150,7 @@ spec = do
             file
             [ Copy
                 ( CopyArgs [ SourcePath "foo" ] (TargetPath "bar") )
-                ( CopyFlags NoChown NoChmod NoLink NoSource [Exclude "*.tmp", Exclude "*.log"] )
+                ( CopyFlags NoChown NoChmod NoLink NoParents NoSource [Exclude "*.tmp", Exclude "*.log"] )
             ]
     it "with exclude and other flags" $
       let file = Text.unlines ["COPY --chown=root:root --exclude=*.tmp foo bar"]
@@ -148,7 +158,7 @@ spec = do
             file
             [ Copy
                 ( CopyArgs [ SourcePath "foo" ] (TargetPath "bar") )
-                ( CopyFlags (Chown "root:root") NoChmod NoLink NoSource [Exclude "*.tmp"] )
+                ( CopyFlags (Chown "root:root") NoChmod NoLink NoParents NoSource [Exclude "*.tmp"] )
             ]
 
   describe "Copy with Heredocs" $ do

--- a/test/Language/Docker/ParseCopySpec.hs
+++ b/test/Language/Docker/ParseCopySpec.hs
@@ -86,14 +86,34 @@ spec = do
                 ( CopyArgs [ SourcePath "source" ] ( TargetPath "/target" ) )
                 ( CopyFlags NoChown NoChmod Link NoParents NoSource [])
             ]
+
     it "with parents flag" $
       let file = Text.unlines [ "COPY --parents source /target" ]
        in assertAst
             file
             [ Copy
                 ( CopyArgs [ SourcePath "source" ] ( TargetPath "/target" ) )
-                ( CopyFlags NoChown NoChmod NoLink Parents NoSource [])
+                ( CopyFlags NoChown NoChmod NoLink ( Parents True ) NoSource [])
             ]
+
+    it "with parents flag explicit true" $
+      let file = Text.unlines [ "COPY --parents=true source /target" ]
+       in assertAst
+            file
+            [ Copy
+                ( CopyArgs [ SourcePath "source" ] ( TargetPath "/target" ) )
+                ( CopyFlags NoChown NoChmod NoLink ( Parents True ) NoSource [])
+            ]
+
+    it "with parents flag explicit false" $
+      let file = Text.unlines [ "COPY --parents=false source /target" ]
+       in assertAst
+            file
+            [ Copy
+                ( CopyArgs [ SourcePath "source" ] ( TargetPath "/target" ) )
+                ( CopyFlags NoChown NoChmod NoLink ( Parents False ) NoSource [])
+            ]
+
     it "with from flag" $
       let file = Text.unlines ["COPY --from=node foo bar"]
        in assertAst
@@ -114,7 +134,7 @@ spec = do
                     (Chown "user:group")
                     (Chmod "751")
                     Link
-                    Parents
+                    ( Parents True )
                     (CopySource "node")
                     []
                 )
@@ -131,7 +151,7 @@ spec = do
                     (Chown "user:group")
                     (Chmod "644")
                     Link
-                    Parents
+                    ( Parents True )
                     (CopySource "node")
                     []
                 )

--- a/test/Language/Docker/PrettyPrintSpec.hs
+++ b/test/Language/Docker/PrettyPrintSpec.hs
@@ -24,57 +24,63 @@ spec = do
     it "with just checksum" $ do
       let add = Add
                   ( AddArgs [SourcePath "http://www.example.com/foo"] (TargetPath "bar") )
-                  ( AddFlags ( Checksum "sha256:24454f830cdd" ) NoChown NoChmod NoLink NoUnpack [])
+                  ( AddFlags ( Checksum "sha256:24454f830cdd" ) NoChown NoChmod NoLink NoKeepGitDir NoUnpack [])
        in assertPretty "ADD --checksum=sha256:24454f830cdd http://www.example.com/foo bar" add
     it "with just chown" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChecksum ( Chown "root:root" ) NoChmod NoLink NoUnpack [] )
+                  ( AddFlags NoChecksum ( Chown "root:root" ) NoChmod NoLink NoKeepGitDir NoUnpack [] )
        in assertPretty "ADD --chown=root:root foo bar" add
     it "with just chmod" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChecksum NoChown ( Chmod "751" ) NoLink NoUnpack [] )
+                  ( AddFlags NoChecksum NoChown ( Chmod "751" ) NoLink NoKeepGitDir NoUnpack [] )
        in assertPretty "ADD --chmod=751 foo bar" add
     it "with just link" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChecksum NoChown NoChmod Link NoUnpack [] )
+                  ( AddFlags NoChecksum NoChown NoChmod Link NoKeepGitDir NoUnpack [] )
        in assertPretty "ADD --link foo bar" add
+
+    it "with just keep-git-dir" $ do
+      let add = Add
+                  ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
+                  ( AddFlags NoChecksum NoChown NoChmod NoLink KeepGitDir NoUnpack [] )
+       in assertPretty "ADD --keep-git-dir foo bar" add
     it "with chown, chmod and link" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChecksum ( Chown "root:root" ) ( Chmod "751" ) Link NoUnpack [] )
+                  ( AddFlags NoChecksum ( Chown "root:root" ) ( Chmod "751" ) Link NoKeepGitDir NoUnpack [] )
        in assertPretty "ADD --chown=root:root --chmod=751 --link foo bar" add
     it "with all flags" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags ( Checksum "sha256:24454f830cdd" ) ( Chown "root:root" ) ( Chmod "751" ) Link (Unpack True) [] )
+                  ( AddFlags ( Checksum "sha256:24454f830cdd" ) ( Chown "root:root" ) ( Chmod "751" ) Link NoKeepGitDir (Unpack True) [] )
        in assertPretty "ADD --checksum=sha256:24454f830cdd --chown=root:root --chmod=751 --link --unpack=true foo bar" add
     it "with unpack true" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChecksum NoChown NoChmod NoLink (Unpack True) [] )
+                  ( AddFlags NoChecksum NoChown NoChmod NoLink NoKeepGitDir (Unpack True) [] )
        in assertPretty "ADD --unpack=true foo bar" add
     it "with unpack false" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChecksum NoChown NoChmod NoLink (Unpack False) [] )
+                  ( AddFlags NoChecksum NoChown NoChmod NoLink NoKeepGitDir (Unpack False) [] )
        in assertPretty "ADD --unpack=false foo bar" add
     it "with just exclude" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChecksum NoChown NoChmod NoLink NoUnpack [Exclude "*.tmp"] )
+                  ( AddFlags NoChecksum NoChown NoChmod NoLink NoKeepGitDir NoUnpack [Exclude "*.tmp"] )
        in assertPretty "ADD --exclude=*.tmp foo bar" add
     it "with multiple exclude flags" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChecksum NoChown NoChmod NoLink NoUnpack [Exclude "*.tmp", Exclude "*.log"] )
+                  ( AddFlags NoChecksum NoChown NoChmod NoLink NoKeepGitDir NoUnpack [Exclude "*.tmp", Exclude "*.log"] )
        in assertPretty "ADD --exclude=*.tmp --exclude=*.log foo bar" add
     it "with exclude and other flags" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChecksum (Chown "root:root") NoChmod NoLink NoUnpack [Exclude "*.tmp"] )
+                  ( AddFlags NoChecksum (Chown "root:root") NoChmod NoLink NoKeepGitDir NoUnpack [Exclude "*.tmp"] )
        in assertPretty "ADD --chown=root:root --exclude=*.tmp foo bar" add
 
   describe "pretty print COPY" $ do
@@ -86,30 +92,35 @@ spec = do
     it "with just chown" $ do
       let copy = Copy
                   ( CopyArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( CopyFlags ( Chown "root:root" ) NoChmod NoLink NoSource [] )
+                  ( CopyFlags ( Chown "root:root" ) NoChmod NoLink NoParents NoSource [] )
        in assertPretty "COPY --chown=root:root foo bar" copy
     it "with just chmod" $ do
       let copy = Copy
                   ( CopyArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( CopyFlags NoChown ( Chmod "751" ) NoLink NoSource [] )
+                  ( CopyFlags NoChown ( Chmod "751" ) NoLink NoParents NoSource [] )
        in assertPretty "COPY --chmod=751 foo bar" copy
     it "with just link" $ do
       let copy = Copy
                   ( CopyArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( CopyFlags NoChown NoChmod Link NoSource [] )
+                  ( CopyFlags NoChown NoChmod Link NoParents NoSource [] )
        in assertPretty "COPY --link foo bar" copy
+    it "with just parents" $ do
+      let copy = Copy
+                  ( CopyArgs [SourcePath "foo"] (TargetPath "bar") )
+                  ( CopyFlags NoChown NoChmod NoLink Parents NoSource [] )
+       in assertPretty "COPY --parents foo bar" copy
     it "with source baseimage" $ do
       let copy =
             Copy
               ( CopyArgs [SourcePath "foo"] (TargetPath "bar") )
-              ( CopyFlags NoChown NoChmod NoLink ( CopySource "baseimage" ) [])
+              ( CopyFlags NoChown NoChmod NoLink NoParents ( CopySource "baseimage" ) [])
        in assertPretty "COPY --from=baseimage foo bar" copy
     it "with both chown and chmod" $ do
       let copy =
             Copy
               ( CopyArgs [SourcePath "foo"] (TargetPath "bar") )
               ( CopyFlags
-                  ( Chown "root:root" ) ( Chmod "751" ) NoLink NoSource []
+                  ( Chown "root:root" ) ( Chmod "751" ) NoLink NoParents NoSource []
               )
        in assertPretty "COPY --chown=root:root --chmod=751 foo bar" copy
     it "with all flags" $ do
@@ -120,26 +131,27 @@ spec = do
                   ( Chown "root:root")
                   ( Chmod "751")
                   Link
+                  Parents
                   ( CopySource "baseimage" )
                   []
               )
        in assertPretty
-            "COPY --chown=root:root --chmod=751 --link --from=baseimage foo bar"
+            "COPY --chown=root:root --chmod=751 --link --parents --from=baseimage foo bar"
             copy
     it "with just exclude" $ do
       let copy = Copy
                   ( CopyArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( CopyFlags NoChown NoChmod NoLink NoSource [Exclude "*.tmp"] )
+                  ( CopyFlags NoChown NoChmod NoLink NoParents NoSource [Exclude "*.tmp"] )
        in assertPretty "COPY --exclude=*.tmp foo bar" copy
     it "with multiple exclude flags" $ do
       let copy = Copy
                   ( CopyArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( CopyFlags NoChown NoChmod NoLink NoSource [Exclude "*.tmp", Exclude "*.log"] )
+                  ( CopyFlags NoChown NoChmod NoLink NoParents NoSource [Exclude "*.tmp", Exclude "*.log"] )
        in assertPretty "COPY --exclude=*.tmp --exclude=*.log foo bar" copy
     it "with exclude and other flags" $ do
       let copy = Copy
                   ( CopyArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( CopyFlags (Chown "root:root") NoChmod NoLink NoSource [Exclude "*.tmp"] )
+                  ( CopyFlags (Chown "root:root") NoChmod NoLink NoParents NoSource [Exclude "*.tmp"] )
        in assertPretty "COPY --chown=root:root --exclude=*.tmp foo bar" copy
 
   describe "pretty print # escape" $ do

--- a/test/Language/Docker/PrettyPrintSpec.hs
+++ b/test/Language/Docker/PrettyPrintSpec.hs
@@ -45,8 +45,8 @@ spec = do
     it "with just keep-git-dir" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChecksum NoChown NoChmod NoLink KeepGitDir NoUnpack [] )
-       in assertPretty "ADD --keep-git-dir foo bar" add
+                  ( AddFlags NoChecksum NoChown NoChmod NoLink ( KeepGitDir True ) NoUnpack [] )
+       in assertPretty "ADD --keep-git-dir=true foo bar" add
     it "with chown, chmod and link" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
@@ -104,11 +104,13 @@ spec = do
                   ( CopyArgs [SourcePath "foo"] (TargetPath "bar") )
                   ( CopyFlags NoChown NoChmod Link NoParents NoSource [] )
        in assertPretty "COPY --link foo bar" copy
+
     it "with just parents" $ do
       let copy = Copy
                   ( CopyArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( CopyFlags NoChown NoChmod NoLink Parents NoSource [] )
-       in assertPretty "COPY --parents foo bar" copy
+                  ( CopyFlags NoChown NoChmod NoLink ( Parents True ) NoSource [] )
+       in assertPretty "COPY --parents=true foo bar" copy
+
     it "with source baseimage" $ do
       let copy =
             Copy
@@ -123,6 +125,7 @@ spec = do
                   ( Chown "root:root" ) ( Chmod "751" ) NoLink NoParents NoSource []
               )
        in assertPretty "COPY --chown=root:root --chmod=751 foo bar" copy
+
     it "with all flags" $ do
       let copy =
             Copy
@@ -131,13 +134,14 @@ spec = do
                   ( Chown "root:root")
                   ( Chmod "751")
                   Link
-                  Parents
+                  ( Parents True )
                   ( CopySource "baseimage" )
                   []
               )
        in assertPretty
-            "COPY --chown=root:root --chmod=751 --link --parents --from=baseimage foo bar"
+            "COPY --chown=root:root --chmod=751 --link --parents=true --from=baseimage foo bar"
             copy
+
     it "with just exclude" $ do
       let copy = Copy
                   ( CopyArgs [SourcePath "foo"] (TargetPath "bar") )


### PR DESCRIPTION
`ADD`:
- [--keep-git-dir](https://docs.docker.com/reference/dockerfile/#add---keep-git-dir)
- [--unpack](https://docs.docker.com/reference/dockerfile/#add---unpack)

`COPY`:
- [--parents](https://docs.docker.com/reference/dockerfile/#copy---parents)