### PR TITLE
[FEAT] Add "ADD --unpack" flag support

### DIFF
--- a/src/Language/Docker/Parser/Copy.hs
+++ b/src/Language/Docker/Parser/Copy.hs
@@ -14,6 +14,7 @@ data Flag
   | FlagChown Chown
   | FlagChmod Chmod
   | FlagLink Link
+  | FlagUnpack Unpack
   | FlagSource CopySource
   | FlagExclude Exclude
   | FlagInvalid (Text, Text)
@@ -63,16 +64,18 @@ parseAdd = do
   let chownFlags = [c | FlagChown c <- flags]
   let chmodFlags = [c | FlagChmod c <- flags]
   let linkFlags = [l | FlagLink l <- flags]
+  let unpackFlags = [u | FlagUnpack u <- flags]
   let excludeFlags = [e | FlagExclude e <- flags]
   let invalidFlags = [i | FlagInvalid i <- flags]
   notFollowedBy (string "--") <?>
-    "only the --checksum, --chown, --chmod, --link, --exclude flags or the src and dest paths"
-  case (invalidFlags, checksumFlags, chownFlags, linkFlags, chmodFlags, excludeFlags) of
-    ((k, v) : _, _, _, _, _, _) -> unexpectedFlag k v
-    (_, _ : _ : _, _, _, _, _) -> customError $ DuplicateFlagError "--checksum"
-    (_, _, _ : _ : _, _, _, _) -> customError $ DuplicateFlagError "--chown"
-    (_, _, _, _ : _ : _, _, _) -> customError $ DuplicateFlagError "--chmod"
-    (_, _, _, _, _ : _ : _, _) -> customError $ DuplicateFlagError "--link"
+    "only the --checksum, --chown, --chmod, --link, --unpack, --exclude flags or the src and dest paths"
+  case (invalidFlags, checksumFlags, chownFlags, linkFlags, chmodFlags, unpackFlags, excludeFlags) of
+    ((k, v) : _, _, _, _, _, _, _) -> unexpectedFlag k v
+    (_, _ : _ : _, _, _, _, _, _) -> customError $ DuplicateFlagError "--checksum"
+    (_, _, _ : _ : _, _, _, _, _) -> customError $ DuplicateFlagError "--chown"
+    (_, _, _, _ : _ : _, _, _, _) -> customError $ DuplicateFlagError "--chmod"
+    (_, _, _, _, _ : _ : _, _, _) -> customError $ DuplicateFlagError "--link"
+    (_, _, _, _, _, _ : _ : _, _) -> customError $ DuplicateFlagError "--unpack"
     _ -> do
       let chk = case checksumFlags of
                   [] -> NoChecksum
@@ -86,7 +89,10 @@ parseAdd = do
       let lnk = case linkFlags of
                   [] -> NoLink
                   l : _ -> l
-      fileList "ADD" (\src dest -> Add (AddArgs src dest) (AddFlags chk cho chm lnk excludeFlags))
+      let unp = case unpackFlags of
+                  [] -> NoUnpack
+                  u : _ -> u
+      fileList "ADD" (\src dest -> Add (AddArgs src dest) (AddFlags chk cho chm lnk unp excludeFlags))
 
 heredocList :: (?esc :: Char) =>
                (NonEmpty SourcePath -> TargetPath -> Instruction Text) ->
@@ -126,6 +132,7 @@ addFlag = (FlagChecksum <$> try checksum <?> "--checksum")
   <|> (FlagChown <$> try chown <?> "--chown")
   <|> (FlagChmod <$> try chmod <?> "--chmod")
   <|> (FlagLink <$> try link <?> "--link")
+  <|> (FlagUnpack <$> try unpack <?> "--unpack")
   <|> (FlagExclude <$> try exclude <?> "--exclude")
   <|> (FlagInvalid <$> try anyFlag <?> "other flag")
 
@@ -151,6 +158,12 @@ link :: Parser Link
 link = do
   void $ string "--link"
   return Link
+
+unpack :: Parser Unpack
+unpack = do
+  void $ string "--unpack="
+  val <- string "true" <|> string "false"
+  return $ Unpack (val == "true")
 
 copySource :: (?esc :: Char) => Parser CopySource
 copySource = do

--- a/src/Language/Docker/PrettyPrint.hs
+++ b/src/Language/Docker/PrettyPrint.hs
@@ -160,6 +160,13 @@ prettyPrintLink link =
     Link -> "--link"
     NoLink -> mempty
 
+prettyPrintUnpack :: Unpack -> Doc ann
+prettyPrintUnpack unpack =
+  case unpack of
+    Unpack True -> "--unpack=true"
+    Unpack False -> "--unpack=false"
+    NoUnpack -> mempty
+
 prettyPrintCopySource :: CopySource -> Doc ann
 prettyPrintCopySource source =
   case source of
@@ -327,12 +334,13 @@ prettyPrintInstruction i =
       prettyPrintBaseImage b
     Add
       AddArgs {sourcePaths, targetPath}
-      AddFlags {checksumFlag, chownFlag, chmodFlag, linkFlag, excludeFlags} -> do
+      AddFlags {checksumFlag, chownFlag, chmodFlag, linkFlag, unpackFlag, excludeFlags} -> do
         "ADD"
         prettyPrintChecksum checksumFlag
         prettyPrintChown chownFlag
         prettyPrintChmod chmodFlag
         prettyPrintLink linkFlag
+        prettyPrintUnpack unpackFlag
         prettyPrintExcludes excludeFlags
         prettyPrintFileList sourcePaths targetPath
     Shell args -> do

--- a/src/Language/Docker/Syntax.hs
+++ b/src/Language/Docker/Syntax.hs
@@ -162,6 +162,11 @@ data Link
   | NoLink
   deriving (Show, Eq, Ord)
 
+data Unpack
+  = Unpack !Bool
+  | NoUnpack
+  deriving (Show, Eq, Ord)
+
 data CopySource
   = CopySource !Text
   | NoSource
@@ -218,12 +223,13 @@ data AddFlags
         chownFlag :: !Chown,
         chmodFlag :: !Chmod,
         linkFlag :: !Link,
+        unpackFlag :: !Unpack,
         excludeFlags :: ![Exclude]
       }
   deriving (Show, Eq, Ord)
 
 instance Default AddFlags where
-  def = AddFlags NoChecksum NoChown NoChmod NoLink []
+  def = AddFlags NoChecksum NoChown NoChmod NoLink NoUnpack []
 
 newtype Exclude
   = Exclude

--- a/test/Language/Docker/ParseAddSpec.hs
+++ b/test/Language/Docker/ParseAddSpec.hs
@@ -91,12 +91,12 @@ spec = do
             ]
     it "with all flags" $
       let file =
-            Text.unlines ["ADD --chmod=640 --chown=root:root --checksum=sha256:24454f830cdd --link foo bar"]
+            Text.unlines ["ADD --chmod=640 --chown=root:root --checksum=sha256:24454f830cdd --link --unpack=true foo bar"]
        in assertAst
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags (Checksum "sha256:24454f830cdd") (Chown "root:root") (Chmod "640") Link NoUnpack [] )
+                ( AddFlags (Checksum "sha256:24454f830cdd") (Chown "root:root") (Chmod "640") Link (Unpack True) [] )
             ]
     it "list of quoted files and chown" $
       let file =

--- a/test/Language/Docker/ParseAddSpec.hs
+++ b/test/Language/Docker/ParseAddSpec.hs
@@ -47,7 +47,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["http://www.example.com/foo"]) (TargetPath "bar") )
-                ( AddFlags (Checksum "sha256:24454f830cdd") NoChown NoChmod NoLink [] )
+                ( AddFlags (Checksum "sha256:24454f830cdd") NoChown NoChmod NoLink NoUnpack [] )
             ]
     it "with chown flag" $
       let file = Text.unlines ["ADD --chown=root:root foo bar"]
@@ -55,7 +55,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChecksum (Chown "root:root") NoChmod NoLink [] )
+                ( AddFlags NoChecksum (Chown "root:root") NoChmod NoLink NoUnpack [] )
             ]
     it "with chmod flag" $
       let file = Text.unlines ["ADD --chmod=640 foo bar"]
@@ -63,7 +63,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChecksum NoChown (Chmod "640") NoLink [] )
+                ( AddFlags NoChecksum NoChown (Chmod "640") NoLink NoUnpack [] )
             ]
     it "with link flag" $
       let file = Text.unlines ["ADD --link foo bar"]
@@ -71,7 +71,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChecksum NoChown NoChmod Link [])
+                ( AddFlags NoChecksum NoChown NoChmod Link NoUnpack [])
             ]
     it "with chown and chmod flag" $
       let file = Text.unlines ["ADD --chown=root:root --chmod=640 foo bar"]
@@ -79,7 +79,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChecksum (Chown "root:root") (Chmod "640") NoLink [] )
+                ( AddFlags NoChecksum (Chown "root:root") (Chmod "640") NoLink NoUnpack [] )
             ]
     it "with chown and chmod flag other order" $
       let file = Text.unlines ["ADD --chmod=640 --chown=root:root foo bar"]
@@ -87,7 +87,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChecksum (Chown "root:root") (Chmod "640") NoLink [] )
+                ( AddFlags NoChecksum (Chown "root:root") (Chmod "640") NoLink NoUnpack [] )
             ]
     it "with all flags" $
       let file =
@@ -96,7 +96,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags (Checksum "sha256:24454f830cdd") (Chown "root:root") (Chmod "640") Link [] )
+                ( AddFlags (Checksum "sha256:24454f830cdd") (Chown "root:root") (Chmod "640") Link NoUnpack [] )
             ]
     it "list of quoted files and chown" $
       let file =
@@ -109,7 +109,23 @@ spec = do
                     (fmap SourcePath ["foo", "bar", "baz"])
                     (TargetPath "/app")
                 )
-                ( AddFlags NoChecksum (Chown "user:group") NoChmod NoLink [] )
+                ( AddFlags NoChecksum (Chown "user:group") NoChmod NoLink NoUnpack [] )
+            ]
+    it "with unpack flag true" $
+      let file = Text.unlines ["ADD --unpack=true http://www.example.com/archive.tar.gz /download"]
+       in assertAst
+            file
+            [ Add
+                ( AddArgs (fmap SourcePath ["http://www.example.com/archive.tar.gz"]) (TargetPath "/download") )
+                ( AddFlags NoChecksum NoChown NoChmod NoLink (Unpack True) [] )
+            ]
+    it "with unpack flag false" $
+      let file = Text.unlines ["ADD --unpack=false my-archive.tar.gz ."]
+       in assertAst
+            file
+            [ Add
+                ( AddArgs (fmap SourcePath ["my-archive.tar.gz"]) (TargetPath ".") )
+                ( AddFlags NoChecksum NoChown NoChmod NoLink (Unpack False) [] )
             ]
     it "with exclude flag" $
       let file = Text.unlines ["ADD --exclude=*.tmp foo bar"]
@@ -117,7 +133,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChecksum NoChown NoChmod NoLink [Exclude "*.tmp"] )
+                ( AddFlags NoChecksum NoChown NoChmod NoLink NoUnpack [Exclude "*.tmp"] )
             ]
     it "with multiple exclude flags" $
       let file = Text.unlines ["ADD --exclude=*.tmp --exclude=*.log foo bar"]
@@ -125,7 +141,7 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChecksum NoChown NoChmod NoLink [Exclude "*.tmp", Exclude "*.log"] )
+                ( AddFlags NoChecksum NoChown NoChmod NoLink NoUnpack [Exclude "*.tmp", Exclude "*.log"] )
             ]
     it "with exclude and other flags" $
       let file = Text.unlines ["ADD --chown=root:root --exclude=*.tmp foo bar"]
@@ -133,5 +149,5 @@ spec = do
             file
             [ Add
                 ( AddArgs (fmap SourcePath ["foo"]) (TargetPath "bar") )
-                ( AddFlags NoChecksum (Chown "root:root") NoChmod NoLink [Exclude "*.tmp"] )
+                ( AddFlags NoChecksum (Chown "root:root") NoChmod NoLink NoUnpack [Exclude "*.tmp"] )
             ]

--- a/test/Language/Docker/PrettyPrintSpec.hs
+++ b/test/Language/Docker/PrettyPrintSpec.hs
@@ -24,42 +24,52 @@ spec = do
     it "with just checksum" $ do
       let add = Add
                   ( AddArgs [SourcePath "http://www.example.com/foo"] (TargetPath "bar") )
-                  ( AddFlags ( Checksum "sha256:24454f830cdd" ) NoChown NoChmod NoLink [])
+                  ( AddFlags ( Checksum "sha256:24454f830cdd" ) NoChown NoChmod NoLink NoUnpack [])
        in assertPretty "ADD --checksum=sha256:24454f830cdd http://www.example.com/foo bar" add
     it "with just chown" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChecksum ( Chown "root:root" ) NoChmod NoLink [] )
+                  ( AddFlags NoChecksum ( Chown "root:root" ) NoChmod NoLink NoUnpack [] )
        in assertPretty "ADD --chown=root:root foo bar" add
     it "with just chmod" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChecksum NoChown ( Chmod "751" ) NoLink [] )
+                  ( AddFlags NoChecksum NoChown ( Chmod "751" ) NoLink NoUnpack [] )
        in assertPretty "ADD --chmod=751 foo bar" add
     it "with just link" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChecksum NoChown NoChmod Link [] )
+                  ( AddFlags NoChecksum NoChown NoChmod Link NoUnpack [] )
        in assertPretty "ADD --link foo bar" add
     it "with chown, chmod and link" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChecksum ( Chown "root:root" ) ( Chmod "751" ) Link [] )
+                  ( AddFlags NoChecksum ( Chown "root:root" ) ( Chmod "751" ) Link NoUnpack [] )
        in assertPretty "ADD --chown=root:root --chmod=751 --link foo bar" add
+    it "with unpack true" $ do
+      let add = Add
+                  ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
+                  ( AddFlags NoChecksum NoChown NoChmod NoLink (Unpack True) [] )
+       in assertPretty "ADD --unpack=true foo bar" add
+    it "with unpack false" $ do
+      let add = Add
+                  ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
+                  ( AddFlags NoChecksum NoChown NoChmod NoLink (Unpack False) [] )
+       in assertPretty "ADD --unpack=false foo bar" add
     it "with just exclude" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChecksum NoChown NoChmod NoLink [Exclude "*.tmp"] )
+                  ( AddFlags NoChecksum NoChown NoChmod NoLink NoUnpack [Exclude "*.tmp"] )
        in assertPretty "ADD --exclude=*.tmp foo bar" add
     it "with multiple exclude flags" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChecksum NoChown NoChmod NoLink [Exclude "*.tmp", Exclude "*.log"] )
+                  ( AddFlags NoChecksum NoChown NoChmod NoLink NoUnpack [Exclude "*.tmp", Exclude "*.log"] )
        in assertPretty "ADD --exclude=*.tmp --exclude=*.log foo bar" add
     it "with exclude and other flags" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
-                  ( AddFlags NoChecksum (Chown "root:root") NoChmod NoLink [Exclude "*.tmp"] )
+                  ( AddFlags NoChecksum (Chown "root:root") NoChmod NoLink NoUnpack [Exclude "*.tmp"] )
        in assertPretty "ADD --chown=root:root --exclude=*.tmp foo bar" add
 
   describe "pretty print COPY" $ do

--- a/test/Language/Docker/PrettyPrintSpec.hs
+++ b/test/Language/Docker/PrettyPrintSpec.hs
@@ -46,6 +46,11 @@ spec = do
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
                   ( AddFlags NoChecksum ( Chown "root:root" ) ( Chmod "751" ) Link NoUnpack [] )
        in assertPretty "ADD --chown=root:root --chmod=751 --link foo bar" add
+    it "with all flags" $ do
+      let add = Add
+                  ( AddArgs [SourcePath "foo"] (TargetPath "bar") )
+                  ( AddFlags ( Checksum "sha256:24454f830cdd" ) ( Chown "root:root" ) ( Chmod "751" ) Link (Unpack True) [] )
+       in assertPretty "ADD --checksum=sha256:24454f830cdd --chown=root:root --chmod=751 --link --unpack=true foo bar" add
     it "with unpack true" $ do
       let add = Add
                   ( AddArgs [SourcePath "foo"] (TargetPath "bar") )


### PR DESCRIPTION
This PR adds support for the very convenient [`ADD --unpack`](https://docs.docker.com/reference/dockerfile/#add---unpack) flag. Adds a few tests as well.

Note: I don't know much about haskell but followed the the existing pattern for `ADD` arguments.