### PR TITLE
Add support for short SELinux relabel flags on bind mounts

### DIFF
--- a/src/Language/Docker/Parser/Run.hs
+++ b/src/Language/Docker/Parser/Run.hs
@@ -322,7 +322,13 @@ mountArgUid :: (?esc :: Char) => Parser RunMountArg
 mountArgUid = MountArgUid <$> key "uid" stringArg
 
 mountArgRelabel :: Parser RunMountArg
-mountArgRelabel = MountArgRelabel <$> key "relabel" relabel
+mountArgRelabel =
+  MountArgRelabel
+    <$> choice
+          [ key "relabel" relabel,
+            RelabelShared <$ string "z",
+            RelabelPrivate <$ string "Z"
+          ]
 
 relabel :: Parser Relabel
 relabel = choice [RelabelShared <$ string "shared", RelabelPrivate <$ string "private"]

--- a/test/Language/Docker/ParseRunSpec.hs
+++ b/test/Language/Docker/ParseRunSpec.hs
@@ -734,3 +734,11 @@ spec = do
       let file = Text.unlines
             ["RUN --mount=type=bind,target=/bar,relabel=private echo foo"]
        in assertAst file [ Run $ RunArgs (ArgumentsText "echo foo") flagsRelabelPrivate ]
+    it "RUN with short SELinux relabel z" $
+      let file = Text.unlines
+            ["RUN --mount=type=bind,target=/bar,z echo foo"]
+       in assertAst file [ Run $ RunArgs (ArgumentsText "echo foo") flagsRelabelShared ]
+    it "RUN with short SELinux relabel Z" $
+      let file = Text.unlines
+            ["RUN --mount=type=bind,target=/bar,Z echo foo"]
+       in assertAst file [ Run $ RunArgs (ArgumentsText "echo foo") flagsRelabelPrivate ]


### PR DESCRIPTION
Add support for the short SELinux relabel flags `z` and `Z` on bind mounts. They reuse the existing `Relabel` AST, so the pretty-printer normalizes them to `relabel=shared`/`relabel=private`.

related-to: hadolint/hadolint#974
