### PR TITLE
parser: do not consume the newline that ends a heredoc terminator line

### DIFF
--- a/src/Language/Docker/Parser/Prelude.hs
+++ b/src/Language/Docker/Parser/Prelude.hs
@@ -202,8 +202,11 @@ heredocContent marker = do
     termination :: Parser Text
     termination = try terEOL <|> terEOF
 
+    -- The line break that follows the terminating marker is not part of the
+    -- heredoc: it is the line break that separates this instruction from
+    -- whatever comes next, so it is left for the caller to consume.
     terEOL :: Parser Text
-    terEOL = string $ "\n" <> marker <> "\n"
+    terEOL = string ("\n" <> marker) <* lookAhead (char '\n')
 
     terEOF :: Parser Text
     terEOF = do
@@ -215,7 +218,7 @@ heredocContent marker = do
     delimiter = try delEOL <|> delEOF
 
     delEOL :: Parser Text
-    delEOL = string $ marker <> "\n"
+    delEOL = string marker <* lookAhead (char '\n')
 
     delEOF :: Parser Text
     delEOF = do

--- a/test/Language/Docker/ParseCopySpec.hs
+++ b/test/Language/Docker/ParseCopySpec.hs
@@ -314,3 +314,23 @@ spec = do
                   ( CopyArgs [ SourcePath "FOO" ] ( TargetPath "/target" ) )
                   def
               ]
+    it "heredoc followed by another instruction" $
+      let file = Text.unlines ["COPY <<EOF /target", "content", "EOF", "COPY a b"]
+       in assertAst
+            file
+              [ Copy
+                  ( CopyArgs [ SourcePath "EOF" ] ( TargetPath "/target" ) )
+                  def,
+                Copy
+                  ( CopyArgs [ SourcePath "a" ] ( TargetPath "b" ) )
+                  def
+              ]
+    it "empty heredoc followed by a comment" $
+      let file = Text.unlines ["COPY <<EOF /target", "EOF", "# comment"]
+       in assertAst
+            file
+              [ Copy
+                  ( CopyArgs [ SourcePath "EOF" ] ( TargetPath "/target" ) )
+                  def,
+                Comment " comment"
+              ]

--- a/test/Language/Docker/ParseRunSpec.hs
+++ b/test/Language/Docker/ParseRunSpec.hs
@@ -567,6 +567,30 @@ spec = do
       let file = "RUN <<EOF\nEOF"
           flags = def { security = Nothing }
        in assertAst file [ Run $ RunArgs (ArgumentsText "") flags ]
+    it "heredoc followed by a comment" $
+      let file = Text.unlines [ "RUN <<EOF", "echo foo", "EOF", "# comment" ]
+          flags = def { security = Nothing }
+       in assertAst
+            file
+            [ Run $ RunArgs (ArgumentsText "echo foo") flags,
+              Comment " comment"
+            ]
+    it "heredoc followed by another instruction" $
+      let file = Text.unlines [ "RUN <<EOF", "echo foo", "EOF", "RUN echo bar" ]
+          flags = def { security = Nothing }
+       in assertAst
+            file
+            [ Run $ RunArgs (ArgumentsText "echo foo") flags,
+              Run $ RunArgs (ArgumentsText "echo bar") flags
+            ]
+    it "empty heredoc followed by a comment" $
+      let file = Text.unlines [ "RUN <<EOF", "EOF", "# comment" ]
+          flags = def { security = Nothing }
+       in assertAst
+            file
+            [ Run $ RunArgs (ArgumentsText "") flags,
+              Comment " comment"
+            ]
     it "evil heredoc" $
       let file = Text.unlines [ "RUN <<EOF foo", "bar EOF", "EOF"]
           flags = def { security = Nothing }


### PR DESCRIPTION
closes #99
related-to: hadolint/hadolint#960

### What I did

Anything that follows a heredoc immediately — a comment or the next instruction — fails to parse:

```dockerfile
RUN <<EOF
echo foo
EOF
# comment
```

```
Dockerfile:4:1: unexpected '#'
expecting a new line followed by the next instruction
```

Both reporters noticed that the error disappears if you add an empty line after the terminator,
or a single space before the `#`. That is the signature of the defect: the character is fine,
the *newline* is gone.

### How I did it

`heredocContent` (`src/Language/Docker/Parser/Prelude.hs`) recognises the terminator as

```haskell
terEOL = string $ "\n" <> marker <> "\n"
```

so it consumes the line break that comes *after* the marker. The top-level loop in
`Language/Docker/Parser.hs` then asks for a separator:

```haskell
i <- parseInstruction
eol <|> eof <?> "a new line followed by the next instruction"
```

and there is nothing left to consume — hence the error, and hence the two workarounds: an empty
line supplies a second newline, and a space before `#` is caught by the `onlySpaces1` branch
of `eol`.

The patch stops at the marker and only looks ahead for the newline, so the line break stays
available for the caller. `delEOL` (the empty-heredoc delimiter) has the same shape and the same
defect, and is fixed symmetrically — it is reachable: it is the branch taken by the existing
"empty heredoc" test, which I confirmed with a `traceM` probe before touching it.

`terEOF`/`delEOF` (marker at end of file, no trailing newline) are left alone.

### How to verify it

```
cabal test --test-show-details=always
```

* five new tests in `test/Language/Docker/ParseRunSpec.hs` and
  `test/Language/Docker/ParseCopySpec.hs`: heredoc followed by a comment, heredoc followed by
  another instruction, and the same two for an empty heredoc;
* before the change: `302 examples, 5 failures`, each with the exact error from the issues;
* after: `302 examples, 0 failures` (the 297 pre-existing tests are untouched), including
  "empty heredoc", "empty heredoc not followed by newline" and "evil heredoc";
* `hlint src/ test/` reports the same 5 hints before and after the patch.

Environment: GHC 9.8.4, `cabal test` as in `.github/workflows/haskell.yml`.
